### PR TITLE
fix: wrap validation inspector responses

### DIFF
--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -1037,19 +1037,19 @@ export async function executeInspectorCommand(cwd: string, inspection: RunInspec
     return { output: renderVerification(inspection) };
   }
   if (trimmed === "show validation") {
-    return renderValidation(inspection);
+    return { output: renderValidation(inspection) };
   }
   if (trimmed === "show pyramid") {
-    return renderValidationPyramid(inspection);
+    return { output: await renderValidationPyramid(inspection) };
   }
   if (trimmed === "show coverage") {
-    return renderValidationCoverage(inspection);
+    return { output: await renderValidationCoverage(inspection) };
   }
   if (trimmed === "show ci-validation") {
-    return renderValidationCi(inspection);
+    return { output: await renderValidationCi(inspection) };
   }
   if (trimmed === "show tool-research") {
-    return renderValidationToolResearch(inspection);
+    return { output: await renderValidationToolResearch(inspection) };
   }
   if (trimmed === "show review") {
     return { output: renderDeliverReview(inspection) };


### PR DESCRIPTION
## Summary
- wrap validation inspector views in the inspector command response contract
- await async validation artifact readers in command dispatch
- unblock release CI for the deliver validation slice

## Verification
- npm run typecheck
- npm test
- npm run build