### PR TITLE
feat: refresh tty dashboard live status

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,18 +366,21 @@ cstack inspect
 cstack inspect <run-id> --interactive
 ```
 
-While a run is active in a normal terminal, `cstack` now renders a bounded ANSI dashboard instead of endlessly appending log lines.
+While a run is active in a normal terminal, `cstack` renders a bounded ANSI dashboard instead of endlessly appending log lines.
 
 The live dashboard shows:
 
-- workflow, status, elapsed time, and session
-- stage strip
-- specialist strip when relevant
-- observed activity
-- inferred next step
+- a header with workflow, run id, status, current stage, live elapsed time, and session
+- a stage strip
+- a specialist strip when relevant
+- an observed activity line
+- a visible pulse/liveness indicator so you know the run is still moving
 - bounded recent activity
+- a footer with artifact and inspection hints
 
-In non-interactive shells, CI logs, or redirected output, it falls back to plain progress lines such as:
+The elapsed timer keeps ticking while the run is active. Color and a few emoji improve scanability in TTYs, but the dashboard still includes text labels so state remains understandable without color.
+
+In non-interactive shells, CI logs, or redirected output, it falls back to plain append-only progress lines such as:
 
 ```text
 [cstack discover <run-id> +0:00] Starting Codex run

--- a/docs/specs/cstack-spec-v0.1.md
+++ b/docs/specs/cstack-spec-v0.1.md
@@ -331,6 +331,85 @@ When a child session id is observed, the wrapper records that observation back i
 
 ## Run Ledger and Inspection
 
+## Active TTY Dashboard
+
+Active TTY runs use a bounded dashboard rather than an endlessly growing log tail.
+
+The dashboard contract is:
+
+- observable state only
+- bounded repainting
+- explicit header, body, and footer regions
+- live elapsed-time updates while the run is active
+- color and emoji as scanability aids, not as the only signal
+- readable plain-line fallback outside TTYs
+
+### Header
+
+The header must show at minimum:
+
+- workflow
+- run id or compact run id
+- current status
+- current stage when known
+- live elapsed time that visibly updates while work is still running
+- session id when relevant
+
+The elapsed counter must not remain static during active execution. A repaint-only dashboard that updates events but leaves elapsed time frozen is out of contract.
+
+### Body
+
+The body must show at minimum:
+
+- a stage progress strip
+- a specialist strip when relevant
+- bounded recent activity
+- a clear liveness signal so the operator knows the run is still alive
+
+The liveness signal may use:
+
+- an animated status glyph
+- a heartbeat indicator
+- a rotating progress marker
+- a freshness hint tied to recent activity
+
+It must remain:
+
+- bounded
+- readable
+- obviously alive
+- not spammy
+
+### Footer
+
+The footer must show at minimum:
+
+- artifact or inspection hints
+- the next useful operator action when appropriate
+- interactive hinting when a TTY-only follow-up is available
+
+### Visual Design
+
+TTY dashboards should be more expressive than plain logs, but still operationally trustworthy.
+
+Required design rules:
+
+- richer ANSI color is allowed and encouraged in TTYs
+- emoji may be used when they improve scanability or mood without obscuring meaning
+- status must remain understandable even with color disabled
+- the dashboard should feel alive, not noisy
+- the product must not display fake thought traces or fake internal reasoning
+
+### Non-TTY Behavior
+
+Non-interactive shells, CI logs, and redirected output must continue to use readable append-only progress lines.
+
+Non-TTY output must not depend on:
+
+- live repainting
+- emoji-only signaling
+- color-only signaling
+
 ### `runs`
 
 `cstack runs` is the run ledger over saved run directories.

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -16,11 +16,14 @@ const ANSI = {
   green: "\u001B[32m",
   yellow: "\u001B[33m",
   red: "\u001B[31m",
+  magenta: "\u001B[35m",
   gray: "\u001B[90m",
   clearToEnd: "\u001B[J",
   hideCursor: "\u001B[?25l",
   showCursor: "\u001B[?25h"
 } as const;
+
+const SPINNER_FRAMES = ["🌱", "🚧", "⚙️", "🛰️", "✨", "🔄"] as const;
 
 interface ProgressStream {
   isTTY?: boolean;
@@ -90,6 +93,10 @@ function compactName(input: string): string {
   return input.replace(/-/g, " ");
 }
 
+function shortRunId(input: string): string {
+  return input.length > 28 ? `${input.slice(0, 12)}…${input.slice(-12)}` : input;
+}
+
 function statusColor(status: DashboardStatus): string {
   switch (status) {
     case "completed":
@@ -108,6 +115,24 @@ function statusColor(status: DashboardStatus): string {
   }
 }
 
+function statusIcon(status: DashboardStatus): string {
+  switch (status) {
+    case "completed":
+      return "✅";
+    case "failed":
+      return "❌";
+    case "running":
+      return "🟡";
+    case "deferred":
+      return "🟠";
+    case "skipped":
+      return "⏭️";
+    case "pending":
+    default:
+      return "⏳";
+  }
+}
+
 function statusLabel(status: DashboardStatus): string {
   switch (status) {
     case "completed":
@@ -123,6 +148,29 @@ function statusLabel(status: DashboardStatus): string {
     case "pending":
     default:
       return "plan";
+  }
+}
+
+function workflowIcon(workflow: WorkflowName): string {
+  switch (workflow) {
+    case "discover":
+      return "🧭";
+    case "spec":
+      return "📝";
+    case "build":
+      return "🛠️";
+    case "review":
+      return "🔎";
+    case "ship":
+      return "🚢";
+    case "deliver":
+      return "📦";
+    case "intent":
+      return "🎯";
+    case "update":
+      return "⬆️";
+    default:
+      return "⚙️";
   }
 }
 
@@ -183,12 +231,15 @@ export class ProgressReporter {
   private lastEvent: RunEvent | null = null;
   private started = false;
   private closed = false;
+  private startedAtMs: number | null = null;
+  private ticker: ReturnType<typeof setInterval> | null = null;
+  private spinnerIndex = 0;
 
   constructor(workflow: WorkflowName, runId: string, stream: ProgressStream = process.stdout) {
     this.workflow = workflow;
     this.runId = runId;
     this.stream = stream;
-    this.colorsEnabled = Boolean(stream.isTTY && process.env.NO_COLOR !== "1");
+    this.colorsEnabled = Boolean(stream.isTTY && !process.env.NO_COLOR);
     this.dashboardEnabled = Boolean(stream.isTTY && process.env.TERM && process.env.TERM !== "dumb");
     this.historyLimit = 6;
     this.stages =
@@ -258,6 +309,9 @@ export class ProgressReporter {
   }
 
   emit(event: RunEvent): void {
+    if (this.startedAtMs === null) {
+      this.startedAtMs = Date.now() - event.elapsedMs;
+    }
     this.lastEvent = event;
     this.history = [...this.history, event].slice(-this.historyLimit);
 
@@ -269,6 +323,7 @@ export class ProgressReporter {
     if (!this.started) {
       this.stream.write(ANSI.hideCursor);
       this.started = true;
+      this.startTicker();
     }
 
     if (event.type === "completed" || event.type === "failed") {
@@ -292,8 +347,33 @@ export class ProgressReporter {
     }
 
     this.closed = true;
+    this.stopTicker();
     this.stream.write("\n");
     this.stream.write(ANSI.showCursor);
+  }
+
+  private startTicker(): void {
+    if (this.ticker || !this.dashboardEnabled) {
+      return;
+    }
+
+    this.ticker = setInterval(() => {
+      if (this.closed) {
+        this.stopTicker();
+        return;
+      }
+      this.spinnerIndex = (this.spinnerIndex + 1) % SPINNER_FRAMES.length;
+      this.render();
+    }, 250);
+    this.ticker.unref?.();
+  }
+
+  private stopTicker(): void {
+    if (!this.ticker) {
+      return;
+    }
+    clearInterval(this.ticker);
+    this.ticker = null;
   }
 
   private render(): void {
@@ -311,23 +391,32 @@ export class ProgressReporter {
 
   private buildDashboardLines(): string[] {
     const status = this.lastEvent?.type === "failed" ? "failed" : this.lastEvent?.type === "completed" ? "completed" : "running";
-    const elapsed = this.lastEvent ? formatElapsed(this.lastEvent.elapsedMs) : "0:00";
+    const elapsed = formatElapsed(this.currentElapsedMs());
     const session = findLastEvent(this.history, (event) => event.type === "session")?.message ?? "pending";
     const lastActivity = this.lastEvent && this.lastEvent.type !== "activity" ? this.lastEvent.message : undefined;
     const recentObservedActivity =
       findLastEvent(this.history, (event) => event.type === "activity" || event.type === "heartbeat")?.message ??
       "waiting for activity";
     const currentLineMessage = lastActivity ?? recentObservedActivity;
-    const header = `${colorize("cstack", ANSI.bold, this.colorsEnabled)} ${colorize(this.workflow, ANSI.cyan, this.colorsEnabled)}  ${colorize(this.runId, ANSI.dim, this.colorsEnabled)}`;
+    const spinner = this.closed ? statusIcon(status) : SPINNER_FRAMES[this.spinnerIndex];
+    const currentStage = this.currentStageLabel();
+    const lastObservedAge = this.lastObservedAgeLabel();
+    const header = `${spinner} ${workflowIcon(this.workflow)} ${colorize("cstack", ANSI.bold, this.colorsEnabled)} ${colorize(
+      this.workflow,
+      ANSI.cyan,
+      this.colorsEnabled
+    )}  ${colorize(shortRunId(this.runId), ANSI.dim, this.colorsEnabled)}`;
     const statusLine = [
-      `status ${colorize(status, eventColor(this.lastEvent?.type ?? "starting"), this.colorsEnabled)}`,
-      `elapsed ${colorize(elapsed, ANSI.bold, this.colorsEnabled)}`,
-      `session ${colorize(session, ANSI.dim, this.colorsEnabled)}`
+      `${statusIcon(status)} status ${colorize(status, eventColor(this.lastEvent?.type ?? "starting"), this.colorsEnabled)}`,
+      `🎬 stage ${colorize(currentStage, ANSI.bold, this.colorsEnabled)}`,
+      `⏱ elapsed ${colorize(elapsed, ANSI.bold, this.colorsEnabled)}`,
+      `🧵 session ${colorize(session, ANSI.dim, this.colorsEnabled)}`
     ].join("  |  ");
-    const activityLine = `${colorize("observed", ANSI.bold, this.colorsEnabled)} ${currentLineMessage}`;
+    const activityLine = `${colorize("Observed", ANSI.bold, this.colorsEnabled)} ${currentLineMessage}`;
+    const pulseLine = `${colorize("Pulse", ANSI.bold, this.colorsEnabled)} ${spinner} alive  |  last activity ${lastObservedAge}`;
     const nextStage = this.stages.find((stage) => stage.status === "pending");
     const nextSpecialist = this.specialists.find((specialist) => specialist.status === "pending");
-    const nextLine = `${colorize("next", ANSI.bold, this.colorsEnabled)} ${
+    const nextLine = `${colorize("Next", ANSI.bold, this.colorsEnabled)} ${
       status === "completed"
         ? "inspect artifacts or move to the next workflow"
         : nextStage
@@ -337,28 +426,87 @@ export class ProgressReporter {
             : "waiting for the current step to finish"
     }`;
     const stageLine =
-      this.stages.length > 0 ? `${colorize("stages", ANSI.bold, this.colorsEnabled)} ${this.renderItems(this.stages)}` : undefined;
+      this.stages.length > 0 ? `${colorize("Stages", ANSI.bold, this.colorsEnabled)} ${this.renderItems(this.stages)}` : undefined;
     const specialistLine =
       this.specialists.length > 0
-        ? `${colorize("specialists", ANSI.bold, this.colorsEnabled)} ${this.renderItems(this.specialists)}`
+        ? `${colorize("Specialists", ANSI.bold, this.colorsEnabled)} ${this.renderItems(this.specialists)}`
         : undefined;
-    const activityHeader = colorize("recent activity", ANSI.bold, this.colorsEnabled);
-    const activityLines = this.history.slice(-5).map((event) => {
+    const activityHeader = colorize("Recent activity", ANSI.bold, this.colorsEnabled);
+    const activityLines = this.history.slice(-4).map((event) => {
       const label = colorize(`[${streamTag(event)} +${formatElapsed(event.elapsedMs)}]`, eventColor(event.type), this.colorsEnabled);
       return `${label} ${event.message}`;
     });
+    const footerDivider = colorize("─".repeat(24), ANSI.gray, this.colorsEnabled);
+    const footerHints = [
+      `${colorize("Footer", ANSI.bold, this.colorsEnabled)} 📂 inspect later with ${colorize(`cstack inspect ${this.runId}`, ANSI.dim, this.colorsEnabled)}`,
+      status === "completed"
+        ? `${colorize("Hint", ANSI.bold, this.colorsEnabled)} 🎉 run finished, open artifacts or enter the post-run inspector`
+        : `${colorize("Hint", ANSI.bold, this.colorsEnabled)} 👀 dashboard is live while the run is active`
+    ];
 
-    return [header, statusLine, stageLine, specialistLine, activityLine, nextLine, activityHeader, ...activityLines].filter(
-      Boolean
-    ) as string[];
+    return [
+      header,
+      statusLine,
+      colorize("─".repeat(24), ANSI.gray, this.colorsEnabled),
+      stageLine,
+      specialistLine,
+      activityLine,
+      pulseLine,
+      activityHeader,
+      ...activityLines,
+      footerDivider,
+      nextLine,
+      ...footerHints
+    ].filter(Boolean) as string[];
   }
 
   private renderItems(items: DashboardItem[]): string {
     return items
       .map((item) => {
-        const label = `${compactName(item.name)}:${statusLabel(item.status)}`;
+        const label = `${statusIcon(item.status)} ${compactName(item.name)}:${statusLabel(item.status)}`;
         return colorize(`[${label}]`, statusColor(item.status), this.colorsEnabled);
       })
       .join(" ");
+  }
+
+  private currentElapsedMs(): number {
+    if (this.startedAtMs === null) {
+      return this.lastEvent?.elapsedMs ?? 0;
+    }
+    if (this.closed) {
+      return this.lastEvent?.elapsedMs ?? Math.max(0, Date.now() - this.startedAtMs);
+    }
+    return Math.max(0, Date.now() - this.startedAtMs);
+  }
+
+  private currentStageLabel(): string {
+    const runningStage = this.stages.find((stage) => stage.status === "running");
+    if (runningStage) {
+      return compactName(runningStage.name);
+    }
+    const deferredStage = this.stages.find((stage) => stage.status === "deferred");
+    if (deferredStage) {
+      return compactName(deferredStage.name);
+    }
+    const failedStage = this.stages.find((stage) => stage.status === "failed");
+    if (failedStage) {
+      return compactName(failedStage.name);
+    }
+    const completedStage = [...this.stages].reverse().find((stage) => stage.status === "completed");
+    if (completedStage) {
+      return compactName(completedStage.name);
+    }
+    const nextStage = this.stages.find((stage) => stage.status === "pending");
+    return nextStage ? compactName(nextStage.name) : compactName(this.workflow);
+  }
+
+  private lastObservedAgeLabel(): string {
+    const recentObserved = findLastEvent(this.history, (event) => event.type === "activity" || event.type === "heartbeat");
+    if (!recentObserved) {
+      return "awaiting first signal";
+    }
+    const ageMs = Math.max(0, this.currentElapsedMs() - recentObserved.elapsedMs);
+    const seconds = Math.floor(ageMs / 1000);
+    return seconds === 0 ? "just now" : `${seconds}s ago`;
   }
 }

--- a/test/progress.test.ts
+++ b/test/progress.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ProgressReporter, buildEvent } from "../src/progress.js";
 
 interface FakeStream {
@@ -23,6 +23,7 @@ function makeStream(isTTY: boolean): FakeStream {
 const originalTerm = process.env.TERM;
 
 afterEach(() => {
+  vi.useRealTimers();
   if (originalTerm === undefined) {
     delete process.env.TERM;
     return;
@@ -43,6 +44,20 @@ describe("ProgressReporter", () => {
     expect(output).toContain("Activity (stdout): scanning repository context");
   });
 
+  it("falls back to plain progress lines when TERM is dumb", () => {
+    process.env.TERM = "dumb";
+    const stream = makeStream(true);
+    const reporter = new ProgressReporter("spec", "run-dumb", stream);
+
+    reporter.emit(buildEvent("starting", 0, "Running codex exec in repo"));
+    reporter.emit(buildEvent("activity", 1000, "scanning repository context", "stdout"));
+
+    const output = stream.writes.join("");
+    expect(output).toContain("Starting Codex run");
+    expect(output).toContain("Activity (stdout): scanning repository context");
+    expect(output).not.toContain("\u001B[?25l");
+  });
+
   it("renders a bounded dashboard for tty streams and restores the cursor", () => {
     process.env.TERM = "xterm-256color";
     const stream = makeStream(true);
@@ -55,15 +70,37 @@ describe("ProgressReporter", () => {
 
     const output = stream.writes.join("");
     expect(output).toContain("\u001B[?25l");
-    expect(output).toContain("stages");
-    expect(output).toContain("[discover:done]");
-    expect(output).toContain("observed");
-    expect(output).toContain("next");
-    expect(output).toContain("recent activity");
+    expect(output).toContain("Stages");
+    expect(output).toContain("✅ discover:done");
+    expect(output).toContain("Observed");
+    expect(output).toContain("Next");
+    expect(output).toContain("Recent activity");
+    expect(output).toContain("Footer");
     expect(output).toContain("session-abc");
     expect(output).toContain("scanning repository context");
     expect(output).toContain("\u001B[?25h");
     expect(output).toContain("\u001B[");
     expect(output).not.toContain("Activity (stdout):");
+  });
+
+  it("updates the elapsed timer while the dashboard is active", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-15T06:30:00Z"));
+    process.env.TERM = "xterm-256color";
+    const stream = makeStream(true);
+    const reporter = new ProgressReporter("build", "run-789", stream);
+
+    reporter.emit(buildEvent("starting", 0, "Running codex in repo"));
+    const initialOutput = stream.writes.join("");
+    expect(initialOutput).toContain("⏱ elapsed");
+    expect(initialOutput).toContain("0:00");
+
+    vi.advanceTimersByTime(1250);
+    const updatedOutput = stream.writes.join("");
+    expect(updatedOutput).toContain("Pulse");
+    expect(updatedOutput).toContain("alive");
+    expect(updatedOutput).toContain("0:01");
+
+    reporter.emit(buildEvent("completed", 2000, "Exit code 0"));
   });
 });


### PR DESCRIPTION
## Summary
- tighten the active spec contract for the TTY dashboard
- add a header/body/footer dashboard with richer color and emoji scanability
- keep the elapsed timer live during active runs and preserve non-TTY fallback behavior

## Verification
- npm run typecheck
- npm test
- npm run build
- PTY smoke of   PATH=<fake-codex-shim> node ./bin/cstack.js spec "TTY dashboard smoke"