### PR TITLE
fix: track downstream intent workflow progress

### DIFF
--- a/src/commands/deliver.ts
+++ b/src/commands/deliver.ts
@@ -14,6 +14,10 @@ export interface DeliverCliOptions {
   allowDirty?: boolean;
 }
 
+export interface DeliverRunHooks {
+  onRunCreated?: (run: RunRecord) => Promise<void> | void;
+}
+
 async function readPromptFromStdin(): Promise<string> {
   if (process.stdin.isTTY) {
     return "";
@@ -78,7 +82,7 @@ function defaultDeliverPrompt(fromRunId?: string): string {
   return fromRunId ? `Deliver the approved change described by upstream run ${fromRunId}.` : "";
 }
 
-export async function runDeliver(cwd: string, args: string[] = []): Promise<string> {
+export async function runDeliver(cwd: string, args: string[] = [], hooks: DeliverRunHooks = {}): Promise<string> {
   const parsed = parseDeliverArgs(args);
   const stdinPrompt = parsed.prompt || parsed.options.fromRunId ? "" : await readPromptFromStdin();
   const resolvedPrompt = (parsed.prompt || stdinPrompt || defaultDeliverPrompt(parsed.options.fromRunId)).trim();
@@ -146,6 +150,7 @@ export async function runDeliver(cwd: string, args: string[] = []): Promise<stri
   };
 
   await writeRunRecord(runDir, runRecord);
+  await hooks.onRunCreated?.(runRecord);
 
   try {
     const execution = await runDeliverExecution({

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -9,6 +9,10 @@ export interface ReviewCliOptions {
   fromRunId?: string;
 }
 
+export interface ReviewRunHooks {
+  onRunCreated?: (run: RunRecord) => Promise<void> | void;
+}
+
 async function readPromptFromStdin(): Promise<string> {
   if (process.stdin.isTTY) {
     return "";
@@ -52,7 +56,7 @@ function defaultReviewPrompt(fromRunId?: string): string {
   return fromRunId ? `Review the linked upstream run ${fromRunId} and decide whether it is ready.` : "";
 }
 
-export async function runReview(cwd: string, args: string[] = []): Promise<string> {
+export async function runReview(cwd: string, args: string[] = [], hooks: ReviewRunHooks = {}): Promise<string> {
   const parsed = parseReviewArgs(args);
   const stdinPrompt = parsed.prompt || parsed.options.fromRunId ? "" : await readPromptFromStdin();
   const resolvedPrompt = (parsed.prompt || stdinPrompt || defaultReviewPrompt(parsed.options.fromRunId)).trim();
@@ -106,6 +110,7 @@ export async function runReview(cwd: string, args: string[] = []): Promise<strin
     }
   };
   await writeRunRecord(runDir, runRecord);
+  await hooks.onRunCreated?.(runRecord);
 
   try {
     const execution = await runReviewExecution({

--- a/src/commands/ship.ts
+++ b/src/commands/ship.ts
@@ -13,6 +13,10 @@ export interface ShipCliOptions {
   allowDirty?: boolean;
 }
 
+export interface ShipRunHooks {
+  onRunCreated?: (run: RunRecord) => Promise<void> | void;
+}
+
 async function readPromptFromStdin(): Promise<string> {
   if (process.stdin.isTTY) {
     return "";
@@ -73,7 +77,7 @@ function defaultShipPrompt(fromRunId?: string): string {
   return fromRunId ? `Ship the linked upstream run ${fromRunId} and evaluate GitHub readiness.` : "";
 }
 
-export async function runShip(cwd: string, args: string[] = []): Promise<string> {
+export async function runShip(cwd: string, args: string[] = [], hooks: ShipRunHooks = {}): Promise<string> {
   const parsed = parseShipArgs(args);
   const stdinPrompt = parsed.prompt || parsed.options.fromRunId ? "" : await readPromptFromStdin();
   const resolvedPrompt = (parsed.prompt || stdinPrompt || defaultShipPrompt(parsed.options.fromRunId)).trim();
@@ -139,6 +143,7 @@ export async function runShip(cwd: string, args: string[] = []): Promise<string>
     }
   };
   await writeRunRecord(runDir, runRecord);
+  await hooks.onRunCreated?.(runRecord);
 
   try {
     const execution = await runShipExecution({

--- a/src/intent.ts
+++ b/src/intent.ts
@@ -41,6 +41,10 @@ interface StageExecutionResult {
   artifactPath: string;
 }
 
+interface AutoWorkflowHooks {
+  onRunCreated?: (run: RunRecord) => Promise<void> | void;
+}
+
 function ensureUniqueStages(stages: RoutingStagePlan[]): RoutingStagePlan[] {
   const seen = new Set<StageName>();
   return stages.filter((stage) => {
@@ -456,12 +460,13 @@ async function executeAutoWorkflow(options: {
   runId: string;
   workflow: IntentAutoWorkflow;
   stageLineage: StageLineage;
+  hooks?: AutoWorkflowHooks;
 }): Promise<string> {
   const args = buildWorkflowArgs(options.intent, options.runId, options.workflow);
   switch (options.workflow) {
     case "deliver": {
       const { runDeliver } = await import("./commands/deliver.js");
-      const childRunId = await runDeliver(options.cwd, args);
+      const childRunId = await runDeliver(options.cwd, args, options.hooks);
       const childRun = await readRun(options.cwd, childRunId);
       const childStageLineage = await loadStageLineageForRun(options.cwd, childRunId);
       const childRunDir = path.dirname(childRun.finalPath);
@@ -485,7 +490,7 @@ async function executeAutoWorkflow(options: {
     }
     case "review": {
       const { runReview } = await import("./commands/review.js");
-      const childRunId = await runReview(options.cwd, args);
+      const childRunId = await runReview(options.cwd, args, options.hooks);
       const childRun = await readRun(options.cwd, childRunId);
       const childRunDir = path.dirname(childRun.finalPath);
       updateLineageStage(options.stageLineage, "review", {
@@ -500,7 +505,7 @@ async function executeAutoWorkflow(options: {
     }
     case "ship": {
       const { runShip } = await import("./commands/ship.js");
-      const childRunId = await runShip(options.cwd, args);
+      const childRunId = await runShip(options.cwd, args, options.hooks);
       const childRun = await readRun(options.cwd, childRunId);
       const childRunDir = path.dirname(childRun.finalPath);
       updateLineageStage(options.stageLineage, "ship", {
@@ -514,6 +519,145 @@ async function executeAutoWorkflow(options: {
       return childRunId;
     }
   }
+}
+
+function startChildRunTracker(options: {
+  cwd: string;
+  workflow: IntentAutoWorkflow;
+  childRunId: string;
+  runDir: string;
+  runRecord: RunRecord;
+  stageLineage: StageLineage;
+  stageLineagePath: string;
+  events: ReturnType<typeof createEventRecorder>;
+}): () => void {
+  const progressStage: StageName = options.workflow === "deliver" ? "build" : options.workflow;
+  let stopped = false;
+  let syncing = false;
+  let lastMirroredActivity = "";
+  let lastMirroredStage = "";
+  let lastMirroredSessionId = "";
+  let lastMirroredSpecialists = "";
+
+  const sync = async () => {
+    if (stopped || syncing) {
+      return;
+    }
+
+    syncing = true;
+    try {
+      const childRun = await readRun(options.cwd, options.childRunId).catch(() => null);
+      if (!childRun) {
+        return;
+      }
+
+      let runRecordChanged = false;
+      let lineageChanged = false;
+
+      if (childRun.sessionId && childRun.sessionId !== lastMirroredSessionId) {
+        options.runRecord.sessionId = childRun.sessionId;
+        lastMirroredSessionId = childRun.sessionId;
+        runRecordChanged = true;
+      }
+
+      const childCurrentStage = childRun.currentStage ?? options.workflow;
+      if (childCurrentStage !== lastMirroredStage) {
+        lastMirroredStage = childCurrentStage;
+        options.runRecord.currentStage = childCurrentStage;
+        runRecordChanged = true;
+        await options.events.emit("activity", `Downstream ${options.workflow} stage: ${childCurrentStage}`);
+      }
+
+      const childSpecialists = (childRun.activeSpecialists ?? []).join(",");
+      if (childSpecialists !== lastMirroredSpecialists) {
+        lastMirroredSpecialists = childSpecialists;
+        options.runRecord.activeSpecialists = childRun.activeSpecialists ?? [];
+        runRecordChanged = true;
+      }
+
+      if (childRun.lastActivity && childRun.lastActivity !== lastMirroredActivity) {
+        lastMirroredActivity = childRun.lastActivity;
+        await options.events.emit("activity", `Downstream ${options.workflow}: ${childRun.lastActivity}`);
+      }
+
+      const childStageLineage = await loadStageLineageForRun(options.cwd, options.childRunId);
+      if (childStageLineage) {
+        if (options.workflow === "deliver") {
+          for (const stageName of ["build", "review", "ship"] as const) {
+            const childStage = childStageLineage.stages.find((entry) => entry.name === stageName);
+            if (!childStage) {
+              continue;
+            }
+            const stageUpdate: Partial<RoutingStagePlan> = {
+              status: childStage.status,
+              executed: childStage.executed,
+              childRunId: options.childRunId,
+              notes: `Executing through downstream deliver run ${options.childRunId}.`
+            };
+            if (childStage.stageDir) {
+              stageUpdate.stageDir = childStage.stageDir;
+            }
+            if (childStage.artifactPath) {
+              stageUpdate.artifactPath = childStage.artifactPath;
+            }
+            updateLineageStage(options.stageLineage, stageName, stageUpdate);
+            lineageChanged = true;
+            options.events.markStage(stageName, childStage.status === "planned" ? "pending" : childStage.status);
+          }
+        } else {
+          const childStage = childStageLineage.stages.find((entry) => entry.name === options.workflow);
+          if (childStage) {
+            const stageUpdate: Partial<RoutingStagePlan> = {
+              status: childStage.status,
+              executed: childStage.executed,
+              childRunId: options.childRunId,
+              notes: `Executing through downstream ${options.workflow} run ${options.childRunId}.`
+            };
+            if (childStage.stageDir) {
+              stageUpdate.stageDir = childStage.stageDir;
+            }
+            if (childStage.artifactPath) {
+              stageUpdate.artifactPath = childStage.artifactPath;
+            }
+            updateLineageStage(options.stageLineage, options.workflow, stageUpdate);
+            lineageChanged = true;
+            options.events.markStage(options.workflow, childStage.status === "planned" ? "pending" : childStage.status);
+          }
+        }
+      } else {
+        updateLineageStage(options.stageLineage, progressStage, {
+          status: childRun.status === "running" ? "running" : childRun.status === "completed" ? "completed" : "failed",
+          executed: true,
+          childRunId: options.childRunId,
+          notes: `Executing through downstream ${options.workflow} run ${options.childRunId}.`
+        });
+        lineageChanged = true;
+        options.events.markStage(progressStage, childRun.status === "completed" ? "completed" : childRun.status === "failed" ? "failed" : "running");
+      }
+
+      if (lineageChanged) {
+        await writeJson(options.stageLineagePath, options.stageLineage);
+      }
+
+      if (runRecordChanged) {
+        options.runRecord.updatedAt = new Date().toISOString();
+        await writeRunRecord(options.runDir, options.runRecord);
+      }
+    } finally {
+      syncing = false;
+    }
+  };
+
+  const interval = setInterval(() => {
+    void sync();
+  }, 1_500);
+  interval.unref?.();
+  void sync();
+
+  return () => {
+    stopped = true;
+    clearInterval(interval);
+  };
 }
 
 function buildFinalSummary(intent: string, routingPlan: RoutingPlan, stageLineage: StageLineage): string {
@@ -747,18 +891,61 @@ export async function runIntent(cwd: string, intent: string, options: IntentComm
 
     const autoWorkflow = selectAutoWorkflow(routingPlan);
     if (autoWorkflow) {
-      runRecord.currentStage = autoWorkflow;
+      const autoProgressStage: StageName = autoWorkflow === "deliver" ? "build" : autoWorkflow;
+      updateLineageStage(stageLineage, autoProgressStage, {
+        status: "running",
+        executed: true,
+        notes: `Starting downstream ${autoWorkflow} workflow.`
+      });
+      events.markStage(autoProgressStage, "running");
+      runRecord.currentStage = autoProgressStage;
       runRecord.activeSpecialists = [];
       runRecord.updatedAt = new Date().toISOString();
       await writeRunRecord(runDir, runRecord);
+      await writeJson(stageLineagePath, stageLineage);
       await events.emit("activity", `Running downstream ${autoWorkflow} workflow from intent`);
-      await executeAutoWorkflow({
-        cwd,
-        intent: resolvedIntent,
-        runId,
-        workflow: autoWorkflow,
-        stageLineage
-      });
+      let stopTracking: (() => void) | undefined;
+      try {
+        await executeAutoWorkflow({
+          cwd,
+          intent: resolvedIntent,
+          runId,
+          workflow: autoWorkflow,
+          stageLineage,
+          hooks: {
+            onRunCreated: async (childRun) => {
+              updateLineageStage(stageLineage, autoProgressStage, {
+                status: "running",
+                executed: true,
+                childRunId: childRun.id,
+                notes: `Executing through downstream ${autoWorkflow} run ${childRun.id}.`
+              });
+              runRecord.currentStage = childRun.currentStage ?? autoProgressStage;
+              runRecord.activeSpecialists = childRun.activeSpecialists ?? [];
+              if (childRun.sessionId) {
+                runRecord.sessionId = childRun.sessionId;
+              }
+              runRecord.updatedAt = new Date().toISOString();
+              runRecord.lastActivity = `Downstream ${autoWorkflow} run ${childRun.id} started`;
+              await writeRunRecord(runDir, runRecord);
+              await writeJson(stageLineagePath, stageLineage);
+              await events.emit("activity", `Downstream ${autoWorkflow} run ${childRun.id} started`);
+              stopTracking = startChildRunTracker({
+                cwd,
+                workflow: autoWorkflow,
+                childRunId: childRun.id,
+                runDir,
+                runRecord,
+                stageLineage,
+                stageLineagePath,
+                events
+              });
+            }
+          }
+        });
+      } finally {
+        stopTracking?.();
+      }
       await writeJson(stageLineagePath, stageLineage);
       for (const stage of stageLineage.stages) {
         if (stage.executed) {

--- a/test/intent.test.ts
+++ b/test/intent.test.ts
@@ -133,6 +133,36 @@ describe("intent router", () => {
     }
   });
 
+  it("tracks downstream review progress in the parent intent run", async () => {
+    await runIntent(repoDir, "What are the gaps in the current project?", {
+      entrypoint: "bare",
+      dryRun: false
+    });
+
+    const runs = await listRuns(repoDir);
+    expect(runs.map((run) => run.workflow).sort()).toEqual(["intent", "review"]);
+
+    const intentRun = await readRun(
+      repoDir,
+      runs.find((entry) => entry.workflow === "intent")!.id
+    );
+    const reviewRun = await readRun(
+      repoDir,
+      runs.find((entry) => entry.workflow === "review")!.id
+    );
+    const intentRunDir = path.dirname(intentRun.finalPath);
+    const lineage = JSON.parse(await fs.readFile(path.join(intentRunDir, "stage-lineage.json"), "utf8")) as StageLineage;
+    const eventsBody = await fs.readFile(path.join(intentRunDir, "events.jsonl"), "utf8");
+
+    expect(intentRun.status).toBe("completed");
+    expect(intentRun.sessionId).toBe(reviewRun.sessionId);
+    expect(lineage.stages.find((stage) => stage.name === "review")?.status).toBe("completed");
+    expect(lineage.stages.find((stage) => stage.name === "review")?.childRunId).toBe(reviewRun.id);
+    expect(eventsBody).toContain("Running downstream review workflow from intent");
+    expect(eventsBody).toContain(`Downstream review run ${reviewRun.id} started`);
+    expect(eventsBody).toContain("Downstream review stage: review");
+  });
+
   it("supports dry-run routing without executing stages", async () => {
     await runIntent(repoDir, "Plan a compliance-safe billing migration", {
       entrypoint: "run",


### PR DESCRIPTION
## Summary
- mark downstream intent child workflows as running in the parent before handoff
- mirror child run id, session id, stage progress, and activity back into the parent intent run
- add regression coverage for intent -> review progress propagation

## Problem
Intent runs that auto-routed into downstream workflows could look stuck on the last completed stage. The parent dashboard kept showing `spec` even while downstream `review` was running, and `session pending`/stale activity made the run look idle.

## Verification
- npm run typecheck
- npm test
- npm run build
