### PR TITLE
fix: suppress child inspect prompts in intent runs

### DIFF
--- a/src/commands/deliver.ts
+++ b/src/commands/deliver.ts
@@ -16,6 +16,7 @@ export interface DeliverCliOptions {
 
 export interface DeliverRunHooks {
   onRunCreated?: (run: RunRecord) => Promise<void> | void;
+  suppressInteractiveInspect?: boolean;
 }
 
 async function readPromptFromStdin(): Promise<string> {
@@ -243,7 +244,9 @@ export async function runDeliver(cwd: string, args: string[] = [], hooks: Delive
         `  ${path.relative(cwd, path.join(runDir, "run.json"))}`
       ].join("\n") + "\n"
     );
-    await maybeOfferInteractiveInspect(cwd, runId);
+    if (!hooks.suppressInteractiveInspect) {
+      await maybeOfferInteractiveInspect(cwd, runId);
+    }
     return runId;
   } catch (error) {
     runRecord.status = "failed";

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -11,6 +11,7 @@ export interface ReviewCliOptions {
 
 export interface ReviewRunHooks {
   onRunCreated?: (run: RunRecord) => Promise<void> | void;
+  suppressInteractiveInspect?: boolean;
 }
 
 async function readPromptFromStdin(): Promise<string> {
@@ -159,7 +160,9 @@ export async function runReview(cwd: string, args: string[] = [], hooks: ReviewR
         `  ${path.relative(cwd, path.join(runDir, "run.json"))}`
       ].join("\n") + "\n"
     );
-    await maybeOfferInteractiveInspect(cwd, runId);
+    if (!hooks.suppressInteractiveInspect) {
+      await maybeOfferInteractiveInspect(cwd, runId);
+    }
     return runId;
   } catch (error) {
     runRecord.status = "failed";

--- a/src/commands/ship.ts
+++ b/src/commands/ship.ts
@@ -15,6 +15,7 @@ export interface ShipCliOptions {
 
 export interface ShipRunHooks {
   onRunCreated?: (run: RunRecord) => Promise<void> | void;
+  suppressInteractiveInspect?: boolean;
 }
 
 async function readPromptFromStdin(): Promise<string> {
@@ -208,7 +209,9 @@ export async function runShip(cwd: string, args: string[] = [], hooks: ShipRunHo
         `  ${path.relative(cwd, path.join(runDir, "run.json"))}`
       ].join("\n") + "\n"
     );
-    await maybeOfferInteractiveInspect(cwd, runId);
+    if (!hooks.suppressInteractiveInspect) {
+      await maybeOfferInteractiveInspect(cwd, runId);
+    }
     return runId;
   } catch (error) {
     runRecord.status = "failed";

--- a/src/intent.ts
+++ b/src/intent.ts
@@ -43,6 +43,7 @@ interface StageExecutionResult {
 
 interface AutoWorkflowHooks {
   onRunCreated?: (run: RunRecord) => Promise<void> | void;
+  suppressInteractiveInspect?: boolean;
 }
 
 function ensureUniqueStages(stages: RoutingStagePlan[]): RoutingStagePlan[] {
@@ -913,6 +914,7 @@ export async function runIntent(cwd: string, intent: string, options: IntentComm
           workflow: autoWorkflow,
           stageLineage,
           hooks: {
+            suppressInteractiveInspect: true,
             onRunCreated: async (childRun) => {
               updateLineageStage(stageLineage, autoProgressStage, {
                 status: "running",

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -124,4 +124,36 @@ describe("runReview", () => {
       stdoutSpy.mockRestore();
     }
   });
+
+  it("suppresses post-run inspection prompts when invoked as a downstream child workflow", async () => {
+    const buildRunId = await seedBuildRun(repoDir);
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stdinIsTTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+    const stdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+
+    try {
+      await runReview(repoDir, ["--from-run", buildRunId, "Review billing cleanup and release safety"], {
+        suppressInteractiveInspect: true
+      });
+
+      const output = stdoutSpy.mock.calls.map(([chunk]) => String(chunk)).join("");
+      expect(output).toContain("Workflow: review");
+      expect(output).not.toContain("Inspect this run now?");
+    } finally {
+      if (stdinIsTTY) {
+        Object.defineProperty(process.stdin, "isTTY", stdinIsTTY);
+      } else {
+        delete (process.stdin as { isTTY?: boolean }).isTTY;
+      }
+      if (stdoutIsTTY) {
+        Object.defineProperty(process.stdout, "isTTY", stdoutIsTTY);
+      } else {
+        delete (process.stdout as { isTTY?: boolean }).isTTY;
+      }
+      stdoutSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- suppress child post-run inspector prompts when `intent` auto-routes into `review`, `ship`, or `deliver`
- keep direct workflow invocations unchanged, including their normal post-run inspect prompt
- add regression coverage for review child workflows in TTY mode

## Problem
Intent runs could show all downstream stages as complete but remain `running` because the child workflow had finished its real work and was then waiting on its own invisible `Inspect this run now? [Y/n]` prompt. The parent tracker saw the child as complete, but the parent could not complete until the child returned.

## Verification
- npm run typecheck
- npm test
- npm run build
