### PR TITLE
fix: surface downstream workflow failures in intent inspect

### DIFF
--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -3,6 +3,7 @@ import { promises as fs } from "node:fs";
 import readline from "node:readline/promises";
 import type {
   ArtifactEntry,
+  ChildRunInspection,
   BuildSessionRecord,
   BuildVerificationRecord,
   DeliverValidationLocalRecord,
@@ -56,6 +57,49 @@ async function readJsonFile<T>(filePath: string): Promise<T | null> {
   } catch {
     return null;
   }
+}
+
+function summarizeChildFailure(child: ChildRunInspection): string {
+  return child.run.error ?? child.run.lastActivity ?? `${child.run.workflow} ${child.run.status}`;
+}
+
+async function loadChildRuns(cwd: string, stageLineage: StageLineage | null): Promise<ChildRunInspection[]> {
+  if (!stageLineage) {
+    return [];
+  }
+
+  const childStages = stageLineage.stages.filter((stage) => stage.childRunId);
+  const loaded = await Promise.all(
+    childStages.map(async (stage) => {
+      const childRunId = stage.childRunId;
+      if (!childRunId) {
+        return null;
+      }
+      try {
+        const run = await readRun(cwd, childRunId);
+        const runDir = runDirForId(cwd, childRunId);
+        const [finalBody, recentEvents, artifacts] = await Promise.all([
+          fs.readFile(run.finalPath, "utf8").catch(() => ""),
+          readRecentEvents(run.eventsPath),
+          walkArtifacts(runDir)
+        ]);
+        return {
+          stageName: stage.name,
+          run,
+          runDir,
+          finalBody,
+          artifacts: artifacts
+            .filter((artifact) => artifact.path !== "context.md" && artifact.path !== "events.jsonl")
+            .slice(0, 8),
+          recentEvents
+        } satisfies ChildRunInspection;
+      } catch {
+        return null;
+      }
+    })
+  );
+
+  return loaded.filter((entry): entry is ChildRunInspection => Boolean(entry));
 }
 
 function badge(name: string, status: string): string {
@@ -519,6 +563,7 @@ export async function loadRunInspection(cwd: string, runId?: string): Promise<Ru
     readJsonFile<GitHubMutationRecord>(githubMutationPath),
     walkArtifacts(runDir)
   ]);
+  const childRuns = await loadChildRuns(cwd, stageLineage);
 
   let finalBody = "";
   try {
@@ -544,7 +589,8 @@ export async function loadRunInspection(cwd: string, runId?: string): Promise<Ru
     githubMutationRecord,
     recentEvents,
     finalBody,
-    artifacts
+    artifacts,
+    childRuns
   };
 }
 
@@ -616,6 +662,7 @@ function renderLineageSection(inspection: RunInspection): string[] {
 
 export function renderInspectionSummary(cwd: string, inspection: RunInspection): string {
   const { run, recentEvents, finalBody } = inspection;
+  const failedChildRuns = inspection.childRuns.filter((child) => child.run.status === "failed");
 
   return (
     [
@@ -640,6 +687,10 @@ export function renderInspectionSummary(cwd: string, inspection: RunInspection):
       inspection.deliverShipRecord ? `- ship readiness: ${inspection.deliverShipRecord.readiness}` : undefined,
       inspection.githubMutationRecord ? `- github mutation: ${inspection.githubMutationRecord.summary}` : undefined,
       inspection.githubDeliveryRecord ? `- github delivery: ${renderGitHubSummary(inspection.githubDeliveryRecord)}` : undefined,
+      ...failedChildRuns.flatMap((child) => [
+        `- downstream ${child.stageName} failed: ${summarizeChildFailure(child)}`,
+        `- inspect child run: cstack inspect ${child.run.id}`
+      ]),
       "",
       "Plan",
       `- stages: ${renderStageStrip(inspection)}`,
@@ -667,7 +718,16 @@ export function renderInspectionSummary(cwd: string, inspection: RunInspection):
 
 function renderArtifacts(inspection: RunInspection): string {
   const artifactLines = inspection.artifacts.map((artifact) => `- ${artifact.path} (${artifact.kind})`);
-  return ["Artifacts:", ...(artifactLines.length > 0 ? artifactLines : ["- none found"])].join("\n");
+  const childLines = inspection.childRuns.flatMap((child) => [
+    `- child ${child.stageName}: ${child.run.id} (${child.run.status})`,
+    `  final: ${path.relative(inspection.run.cwd, child.run.finalPath)}`,
+    ...child.artifacts.slice(0, 4).map((artifact) => `  artifact: ${path.relative(inspection.run.cwd, path.join(child.runDir, artifact.path))}`)
+  ]);
+  return [
+    "Artifacts:",
+    ...(artifactLines.length > 0 ? artifactLines : ["- none found"]),
+    ...(childLines.length > 0 ? ["", "Linked child runs:", ...childLines] : [])
+  ].join("\n");
 }
 
 function renderSession(inspection: RunInspection): string {
@@ -814,6 +874,13 @@ function renderStages(inspection: RunInspection): string {
       if (stage.executed) {
         details.push("executed");
       }
+      const child = stage.childRunId ? inspection.childRuns.find((entry) => entry.run.id === stage.childRunId) : undefined;
+      if (child) {
+        details.push(`child ${child.run.workflow}=${child.run.status}`);
+        if (child.run.status === "failed") {
+          details.push(summarizeChildFailure(child));
+        }
+      }
       if (stage.notes) {
         details.push(stage.notes);
       }
@@ -912,6 +979,12 @@ function renderWhatRemains(inspection: RunInspection): string {
 
   for (const stage of outstandingStages) {
     lines.push(`- stage ${stage.name}: ${stage.status}${stage.notes ? ` (${stage.notes})` : ""}`);
+    const child = stage.childRunId ? inspection.childRuns.find((entry) => entry.run.id === stage.childRunId) : undefined;
+    if (child) {
+      lines.push(`- child ${child.run.workflow} run ${child.run.id}: ${child.run.status}`);
+      lines.push(`- child summary: ${summarizeChildFailure(child)}`);
+      lines.push(`- inspect child with: cstack inspect ${child.run.id}`);
+    }
   }
   for (const specialist of skippedSpecialists) {
     lines.push(`- specialist ${specialist.name}: planned but not executed`);
@@ -1118,7 +1191,33 @@ export async function executeInspectorCommand(cwd: string, inspection: RunInspec
   if (trimmed.startsWith("show stage ")) {
     const stageName = trimmed.slice("show stage ".length).trim();
     const stage = inspection.stageLineage?.stages.find((entry) => entry.name === stageName);
-    return { output: stage ? `${JSON.stringify(stage, null, 2)}\n` : `No stage named \`${stageName}\` was recorded for this run.` };
+    if (!stage) {
+      return { output: `No stage named \`${stageName}\` was recorded for this run.` };
+    }
+    const child = stage.childRunId ? inspection.childRuns.find((entry) => entry.run.id === stage.childRunId) : undefined;
+    return {
+      output:
+        [
+          JSON.stringify(stage, null, 2),
+          child
+            ? [
+                "",
+                "Linked child run:",
+                `- run: ${child.run.id}`,
+                `- workflow: ${child.run.workflow}`,
+                `- status: ${child.run.status}`,
+                child.run.error ? `- error: ${child.run.error}` : undefined,
+                child.run.lastActivity ? `- last activity: ${child.run.lastActivity}` : undefined,
+                `- final: ${path.relative(cwd, child.run.finalPath)}`,
+                `- inspect child with: cstack inspect ${child.run.id}`
+              ]
+                .filter(Boolean)
+                .join("\n")
+            : undefined
+        ]
+          .filter(Boolean)
+          .join("\n") + "\n"
+    };
   }
   if (trimmed.startsWith("show specialist ")) {
     const specialistName = trimmed.slice("show specialist ".length).trim();

--- a/src/intent.ts
+++ b/src/intent.ts
@@ -46,6 +46,10 @@ interface AutoWorkflowHooks {
   suppressInteractiveInspect?: boolean;
 }
 
+function summarizeChildRunOutcome(childRun: RunRecord): string {
+  return childRun.error ?? childRun.lastActivity ?? `${childRun.workflow} ${childRun.status}`;
+}
+
 function ensureUniqueStages(stages: RoutingStagePlan[]): RoutingStagePlan[] {
   const seen = new Set<StageName>();
   return stages.filter((stage) => {
@@ -484,7 +488,7 @@ async function executeAutoWorkflow(options: {
               : stageName === "review"
                 ? path.join(childRunDir, "stages", "review", "artifacts", "verdict.json")
                 : path.join(childRunDir, "stages", "ship", "artifacts", "ship-summary.md"),
-          notes: `Executed through downstream deliver run ${childRunId}.`
+          notes: `Executed through downstream deliver run ${childRunId}. ${summarizeChildRunOutcome(childRun)}`
         });
       }
       return childRunId;
@@ -500,7 +504,7 @@ async function executeAutoWorkflow(options: {
         childRunId,
         stageDir: childRunDir,
         artifactPath: path.join(childRunDir, "artifacts", "verdict.json"),
-        notes: `Executed through downstream review run ${childRunId}.`
+        notes: `Executed through downstream review run ${childRunId}. ${summarizeChildRunOutcome(childRun)}`
       });
       return childRunId;
     }
@@ -515,7 +519,7 @@ async function executeAutoWorkflow(options: {
         childRunId,
         stageDir: childRunDir,
         artifactPath: path.join(childRunDir, "artifacts", "ship-summary.md"),
-        notes: `Executed through downstream ship run ${childRunId}.`
+        notes: `Executed through downstream ship run ${childRunId}. ${summarizeChildRunOutcome(childRun)}`
       });
       return childRunId;
     }
@@ -664,7 +668,9 @@ function startChildRunTracker(options: {
 function buildFinalSummary(intent: string, routingPlan: RoutingPlan, stageLineage: StageLineage): string {
   const stageLines = stageLineage.stages.map(
     (stage) =>
-      `- ${stage.name}: ${stage.status}${stage.executed ? " (executed)" : ""}${stage.childRunId ? ` via ${stage.childRunId}` : ""}`
+      `- ${stage.name}: ${stage.status}${stage.executed ? " (executed)" : ""}${stage.childRunId ? ` via ${stage.childRunId}` : ""}${
+        stage.notes ? `\n  note: ${stage.notes}` : ""
+      }`
   );
   const executedSpecialistLines =
     stageLineage.specialists.length > 0

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,6 +156,16 @@ export interface RunInspection {
   recentEvents: RunEvent[];
   finalBody: string;
   artifacts: ArtifactEntry[];
+  childRuns: ChildRunInspection[];
+}
+
+export interface ChildRunInspection {
+  stageName: StageName;
+  run: RunRecord;
+  runDir: string;
+  finalBody: string;
+  artifacts: ArtifactEntry[];
+  recentEvents: RunEvent[];
 }
 
 export type RunEventType =

--- a/test/inspect.test.ts
+++ b/test/inspect.test.ts
@@ -259,6 +259,127 @@ async function seedIntentRun(repoDir: string): Promise<string> {
   return runId;
 }
 
+async function seedIntentFailedReviewRun(repoDir: string): Promise<string> {
+  const reviewRunId = await seedReviewRun(repoDir);
+  const runId = "2026-03-15T10-05-13-993Z-intent-what-are-the-gaps-in-this-project";
+  const runDir = path.join(repoDir, ".cstack", "runs", runId);
+  await fs.mkdir(path.join(runDir, "artifacts"), { recursive: true });
+
+  const run: RunRecord = {
+    id: runId,
+    workflow: "intent",
+    createdAt: "2026-03-15T10:05:13.000Z",
+    updatedAt: "2026-03-15T10:05:40.000Z",
+    status: "failed",
+    cwd: repoDir,
+    gitBranch: "main",
+    codexVersion: "fake",
+    codexCommand: ["codex", "exec"],
+    promptPath: path.join(runDir, "prompt.md"),
+    finalPath: path.join(runDir, "final.md"),
+    contextPath: path.join(runDir, "context.md"),
+    eventsPath: path.join(runDir, "events.jsonl"),
+    stdoutPath: path.join(runDir, "stdout.log"),
+    stderrPath: path.join(runDir, "stderr.log"),
+    configSources: [],
+    lastActivity: "Intent run finished with downstream workflow failures",
+    summary: "What are the gaps in this project",
+    error: `review failed via ${reviewRunId}`,
+    inputs: {
+      userPrompt: "What are the gaps in this project",
+      entrypoint: "intent",
+      plannedStages: ["discover", "spec", "review"],
+      selectedSpecialists: []
+    }
+  };
+
+  const routingPlan: RoutingPlan = {
+    intent: "What are the gaps in this project",
+    inferredAt: "2026-03-15T10:05:13.000Z",
+    entrypoint: "bare",
+    summary: "Infer discover -> spec -> review with no specialist reviews selected",
+    stages: [
+      { name: "discover", rationale: "Gather repo context.", status: "planned", executed: false },
+      { name: "spec", rationale: "Plan the implementation.", status: "planned", executed: false },
+      { name: "review", rationale: "Gap analysis implies critique.", status: "planned", executed: false }
+    ],
+    specialists: []
+  };
+
+  const childFailure =
+    "Delivery is not ready. The repo has unresolved contract, runtime, and configuration gaps, and there is no verification evidence for this review run.";
+  const lineage: StageLineage = {
+    intent: "What are the gaps in this project",
+    stages: [
+      { name: "discover", rationale: "Gather repo context.", status: "completed", executed: true },
+      { name: "spec", rationale: "Plan the implementation.", status: "completed", executed: true },
+      {
+        name: "review",
+        rationale: "Gap analysis implies critique.",
+        status: "failed",
+        executed: true,
+        childRunId: reviewRunId,
+        stageDir: path.join(repoDir, ".cstack", "runs", reviewRunId),
+        artifactPath: path.join(repoDir, ".cstack", "runs", reviewRunId, "artifacts", "verdict.json"),
+        notes: `Executed through downstream review run ${reviewRunId}. ${childFailure}`
+      }
+    ],
+    specialists: []
+  };
+
+  const events: RunEvent[] = [
+    {
+      timestamp: "2026-03-15T10:05:13.000Z",
+      elapsedMs: 0,
+      type: "starting",
+      message: "Routing intent across discover -> spec -> review"
+    },
+    {
+      timestamp: "2026-03-15T10:05:38.000Z",
+      elapsedMs: 25_000,
+      type: "activity",
+      message: `Downstream review: ${childFailure}`
+    },
+    {
+      timestamp: "2026-03-15T10:05:40.000Z",
+      elapsedMs: 27_000,
+      type: "failed",
+      message: "Intent run finished with downstream workflow failures"
+    }
+  ];
+
+  const finalBody = [
+    "# Intent Run Summary",
+    "",
+    "## Intent",
+    "What are the gaps in this project",
+    "",
+    "## Routing summary",
+    "Infer discover -> spec -> review with no specialist reviews selected",
+    "",
+    "## Stage status",
+    "- discover: completed (executed)",
+    "- spec: completed (executed)",
+    `- review: failed (executed) via ${reviewRunId}`,
+    `  note: Executed through downstream review run ${reviewRunId}. ${childFailure}`,
+    "",
+    "## Planned specialists",
+    "- none selected",
+    "",
+    "## Specialist status",
+    "- none executed",
+    ""
+  ].join("\n");
+
+  await fs.writeFile(path.join(runDir, "run.json"), `${JSON.stringify(run, null, 2)}\n`, "utf8");
+  await fs.writeFile(path.join(runDir, "routing-plan.json"), `${JSON.stringify(routingPlan, null, 2)}\n`, "utf8");
+  await fs.writeFile(path.join(runDir, "stage-lineage.json"), `${JSON.stringify(lineage, null, 2)}\n`, "utf8");
+  await fs.writeFile(path.join(runDir, "events.jsonl"), `${events.map((event) => JSON.stringify(event)).join("\n")}\n`, "utf8");
+  await fs.writeFile(path.join(runDir, "final.md"), `${finalBody}\n`, "utf8");
+
+  return runId;
+}
+
 async function seedBuildRun(repoDir: string): Promise<string> {
   const runId = "2026-03-14T11-00-00-build-billing-cleanup";
   const runDir = path.join(repoDir, ".cstack", "runs", runId);
@@ -1084,5 +1205,21 @@ describe("inspect", () => {
     } finally {
       stdoutSpy.mockRestore();
     }
+  });
+
+  it("surfaces downstream review failure context from a parent intent run", async () => {
+    const failedIntentRunId = await seedIntentFailedReviewRun(repoDir);
+    const inspection = await loadRunInspection(repoDir, failedIntentRunId);
+
+    expect(inspection.childRuns).toHaveLength(1);
+    expect(inspection.childRuns[0]?.run.workflow).toBe("review");
+    await expect(handleInspectorCommand(repoDir, inspection, "1")).resolves.toContain("downstream review failed");
+    await expect(handleInspectorCommand(repoDir, inspection, "1")).resolves.toContain("inspect child run: cstack inspect");
+    await expect(handleInspectorCommand(repoDir, inspection, "artifacts")).resolves.toContain("Linked child runs:");
+    await expect(handleInspectorCommand(repoDir, inspection, "artifacts")).resolves.toContain("artifacts/verdict.json");
+    await expect(handleInspectorCommand(repoDir, inspection, "show stage review")).resolves.toContain("Linked child run:");
+    await expect(handleInspectorCommand(repoDir, inspection, "show stage review")).resolves.toContain("workflow: review");
+    await expect(handleInspectorCommand(repoDir, inspection, "what remains")).resolves.toContain("child summary:");
+    await expect(handleInspectorCommand(repoDir, inspection, "f")).resolves.toContain("note: Executed through downstream review run");
   });
 });


### PR DESCRIPTION
## Summary
- load linked child runs during parent run inspection when stage lineage references `childRunId`
- surface downstream child failure context in the summary, artifacts, stage details, and remaining-work views
- include downstream child outcome notes in intent final summaries and cover the behavior with inspect regression tests

## Testing
- npm run typecheck
- npm test
- npm run build
