### PR TITLE
fix: keep analytical review verdicts from failing intent runs

### DIFF
--- a/docs/specs/cstack-spec-v0.1.md
+++ b/docs/specs/cstack-spec-v0.1.md
@@ -451,7 +451,7 @@ Current inspector views include:
 - delegate and artifact drilldowns
 - `what remains`
 
-For failed or blocked `review`, `ship`, and `deliver` runs, the interactive inspector may also surface explicit mitigation commands. Those commands must derive their prompts from recorded artifacts, link the new run back to the inspected run, and switch the inspector to the newly started workflow once it exists.
+For failed `ship` and `deliver` runs, and for `review` verdicts that are `blocked` or `changes-requested`, the interactive inspector may also surface explicit mitigation commands. Those commands must derive their prompts from recorded artifacts, link the new run back to the inspected run, and switch the inspector to the newly started workflow once it exists.
 
 ## Artifacts and Storage
 

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -135,13 +135,15 @@ export async function runReview(cwd: string, args: string[] = [], hooks: ReviewR
       ...(linkedContext ? { linkedContext } : {})
     });
 
-    runRecord.status = execution.reviewVerdict.status === "ready" ? "completed" : "failed";
+    runRecord.status = execution.executionSucceeded ? "completed" : "failed";
     runRecord.updatedAt = new Date().toISOString();
     delete runRecord.currentStage;
     runRecord.inputs.selectedSpecialists = execution.selectedSpecialists.map((specialist) => specialist.name);
     runRecord.lastActivity = execution.reviewVerdict.summary;
-    if (runRecord.status !== "completed") {
+    if (!execution.executionSucceeded) {
       runRecord.error = execution.reviewVerdict.summary;
+    } else {
+      delete runRecord.error;
     }
     await writeRunRecord(runDir, runRecord);
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -55,6 +55,7 @@ export interface ReviewExecutionResult {
   selectedSpecialists: SpecialistSelection[];
   stageLineage: StageLineage;
   finalBody: string;
+  executionSucceeded: boolean;
 }
 
 async function readJsonFile<T>(filePath: string): Promise<T | null> {
@@ -361,6 +362,7 @@ export async function runReviewExecution(options: ReviewExecutionOptions): Promi
     reviewVerdict,
     selectedSpecialists,
     stageLineage,
-    finalBody
+    finalBody,
+    executionSucceeded: reviewResult.code === 0
   };
 }

--- a/test/fixtures/fake-codex.mjs
+++ b/test/fixtures/fake-codex.mjs
@@ -217,24 +217,48 @@ if (prompt.includes("track in a bounded `cstack discover` research run")) {
     "No blocking gaps detected in the fake fixture."
   ].join("\n");
 } else if (prompt.includes("You are the `Review Lead` for a bounded `cstack deliver` workflow.")) {
-  body = JSON.stringify(
-    {
-      status: "ready",
-      summary: "Review completed with bounded follow-up.",
-      findings: [
-        {
-          severity: "warning",
-          title: "Release readiness follow-up",
-          detail: "Review the release checklist before merge."
-        }
-      ],
-      recommendedActions: ["Review the release checklist before merge."],
-      acceptedSpecialists: [],
-      reportMarkdown: "# Review Findings\n\nBounded follow-up required.\n"
-    },
-    null,
-    2
-  );
+  if (/what are the gaps/i.test(prompt)) {
+    body = JSON.stringify(
+      {
+        status: "blocked",
+        summary: "Major contract, behavior, and process gaps remain unresolved.",
+        findings: [
+          {
+            severity: "error",
+            title: "Contract drift",
+            detail: "The shipped interfaces and the planned contract are no longer aligned."
+          }
+        ],
+        recommendedActions: [
+          "Define a single source of truth for the API contract.",
+          "Add verification evidence before treating the project as delivery-ready."
+        ],
+        acceptedSpecialists: [],
+        reportMarkdown: "# Review Findings\n\nMajor gaps remain unresolved.\n"
+      },
+      null,
+      2
+    );
+  } else {
+    body = JSON.stringify(
+      {
+        status: "ready",
+        summary: "Review completed with bounded follow-up.",
+        findings: [
+          {
+            severity: "warning",
+            title: "Release readiness follow-up",
+            detail: "Review the release checklist before merge."
+          }
+        ],
+        recommendedActions: ["Review the release checklist before merge."],
+        acceptedSpecialists: [],
+        reportMarkdown: "# Review Findings\n\nBounded follow-up required.\n"
+      },
+      null,
+      2
+    );
+  }
 } else if (prompt.includes("You are the `Ship Lead` for a bounded `cstack deliver` workflow.")) {
   body = JSON.stringify(
     {

--- a/test/intent.test.ts
+++ b/test/intent.test.ts
@@ -163,6 +163,37 @@ describe("intent router", () => {
     expect(eventsBody).toContain("Downstream review stage: review");
   });
 
+  it("keeps intent completed when downstream review finds blocked gaps", async () => {
+    await runIntent(repoDir, "What are the gaps in this project", {
+      entrypoint: "bare",
+      dryRun: false
+    });
+
+    const runs = await listRuns(repoDir);
+    const intentRun = await readRun(
+      repoDir,
+      runs.find((entry) => entry.workflow === "intent")!.id
+    );
+    const reviewRun = await readRun(
+      repoDir,
+      runs.find((entry) => entry.workflow === "review")!.id
+    );
+    const intentRunDir = path.dirname(intentRun.finalPath);
+    const reviewRunDir = path.dirname(reviewRun.finalPath);
+    const lineage = JSON.parse(await fs.readFile(path.join(intentRunDir, "stage-lineage.json"), "utf8")) as StageLineage;
+    const reviewVerdict = JSON.parse(await fs.readFile(path.join(reviewRunDir, "artifacts", "verdict.json"), "utf8")) as {
+      status: string;
+      summary: string;
+    };
+
+    expect(intentRun.status).toBe("completed");
+    expect(intentRun.error).toBeUndefined();
+    expect(reviewRun.status).toBe("completed");
+    expect(reviewVerdict.status).toBe("blocked");
+    expect(lineage.stages.find((stage) => stage.name === "review")?.status).toBe("completed");
+    expect(await fs.readFile(intentRun.finalPath, "utf8")).toContain("Major contract, behavior, and process gaps remain unresolved.");
+  });
+
   it("supports dry-run routing without executing stages", async () => {
     await runIntent(repoDir, "Plan a compliance-safe billing migration", {
       entrypoint: "run",

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -156,4 +156,31 @@ describe("runReview", () => {
       stdoutSpy.mockRestore();
     }
   });
+
+  it("keeps the review run completed when the verdict is blocked but the analysis succeeded", async () => {
+    const buildRunId = await seedBuildRun(repoDir);
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    try {
+      await runReview(repoDir, ["--from-run", buildRunId, "What are the gaps in this project"]);
+
+      const runs = await listRuns(repoDir);
+      const reviewRun = runs.find((run) => run.workflow === "review");
+      expect(reviewRun).toBeTruthy();
+
+      const run = await readRun(repoDir, reviewRun!.id);
+      const runDir = path.dirname(run.finalPath);
+      const verdict = JSON.parse(await fs.readFile(path.join(runDir, "artifacts", "verdict.json"), "utf8")) as {
+        status: string;
+        summary: string;
+      };
+
+      expect(run.status).toBe("completed");
+      expect(run.error).toBeUndefined();
+      expect(verdict.status).toBe("blocked");
+      expect(stdoutSpy.mock.calls.map(([chunk]) => String(chunk)).join("")).toContain("Verdict: blocked");
+    } finally {
+      stdoutSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- keep `review` workflow runs completed when analysis succeeds, even if the verdict is `blocked` or `changes-requested`
- preserve blocker information in the review verdict and parent intent summary instead of marking the whole analytical run failed
- cover the exact `What are the gaps in this project` path in review and intent regression tests

## Testing
- npm run typecheck
- npm test
- npm run build
