### PR TITLE
fix: reduce tty dashboard flicker

### DIFF
--- a/src/progress.ts
+++ b/src/progress.ts
@@ -344,6 +344,10 @@ export class ProgressReporter {
       return;
     }
 
+    if (event.type === "activity" || event.type === "heartbeat") {
+      return;
+    }
+
     this.render();
   }
 
@@ -390,7 +394,7 @@ export class ProgressReporter {
       }
       this.spinnerIndex = (this.spinnerIndex + 1) % SPINNER_FRAMES.length;
       this.render();
-    }, 250);
+    }, 500);
     this.ticker.unref?.();
   }
 

--- a/test/progress.test.ts
+++ b/test/progress.test.ts
@@ -104,6 +104,29 @@ describe("ProgressReporter", () => {
     reporter.emit(buildEvent("completed", 2000, "Exit code 0"));
   });
 
+  it("coalesces bursty activity updates onto the ticker cadence", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-15T06:30:00Z"));
+    process.env.TERM = "xterm-256color";
+    const stream = makeStream(true);
+    const reporter = new ProgressReporter("review", "run-burst", stream);
+
+    reporter.emit(buildEvent("starting", 0, "Starting review"));
+    const writesAfterStart = stream.writes.length;
+
+    reporter.emit(buildEvent("activity", 25, "first stderr event", "stderr"));
+    reporter.emit(buildEvent("activity", 50, "second stdout event", "stdout"));
+    reporter.emit(buildEvent("activity", 75, "third stderr event", "stderr"));
+
+    expect(stream.writes.length).toBe(writesAfterStart);
+
+    vi.advanceTimersByTime(500);
+    expect(stream.writes.length).toBeGreaterThan(writesAfterStart);
+    expect(stream.writes.join("")).toContain("third stderr event");
+
+    reporter.emit(buildEvent("completed", 1000, "Exit code 0"));
+  });
+
   it("can suspend and resume a tty dashboard around interactive prompts", () => {
     process.env.TERM = "xterm-256color";
     const stream = makeStream(true);


### PR DESCRIPTION
## Summary
- stop repainting the TTY dashboard immediately for every activity and heartbeat event
- let the live ticker own the redraw cadence between real state transitions
- add a regression test covering bursty mixed stdout/stderr activity

## Testing
- npm run typecheck
- npm test
- npm run build
