### PR TITLE
feat: add analysis-mode review and richer inspect UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Useful inspector commands:
 - `show ship`
 - `show mutation`
 - `show github`
+- `show child <stage>`
 - `show delegate <track>`
 - `show sources <track>`
 - `mitigate`
@@ -246,6 +247,7 @@ Useful inspector commands:
 - `show stage <name>`
 - `show specialist <name>`
 - `show artifact <relative-path>`
+- `gaps`
 - `why deferred <stage>`
 - `what remains`
 - `resume`
@@ -258,11 +260,19 @@ Shortcuts:
 - `2` stages
 - `3` specialists
 - `4` artifacts
+- `g` gaps
 - `f` final output
 - `r` routing
 - `q` exit
 
 For TTY runs, `cstack` may offer `Inspect this run now? [Y/n]` after the summary. Non-interactive shells skip that prompt.
+
+Interactive inspector quality-of-life:
+
+- tab completion for commands and common `show ...` targets
+- dynamic completion for stage names, specialists, artifact paths, delegate tracks, and linked child stages
+- typo suggestions for unknown commands
+- analysis-mode reviews surface gap clusters and recommended next slices directly in the summary
 
 ## Update cstack
 
@@ -525,6 +535,8 @@ Review notes:
 
 - `review` is a standalone critique workflow with `findings.md`, `findings.json`, and `verdict.json`
 - `review --from-run <run-id>` links an upstream build or deliver artifact into the critique context
+- analysis prompts like `What are the gaps in this project` run `review` in analysis mode and produce gap clusters, likely root causes, confidence, and recommended next slices instead of release-gate phrasing
+- readiness phrasing like `ready`, `changes-requested`, and `blocked` is reserved for deliver-stage review and ship-oriented readiness checks
 - bounded specialist reviewers may run when the prompt implies security, audit, traceability, DevSecOps, or release-pipeline risk
 
 Ship notes:

--- a/docs/specs/cstack-spec-v0.1.md
+++ b/docs/specs/cstack-spec-v0.1.md
@@ -132,6 +132,7 @@ Purpose:
 
 - critique a change or linked run
 - surface risks, findings, and next actions
+- support both analysis-style critique and readiness-style critique without conflating them
 
 Execution model:
 
@@ -142,6 +143,14 @@ Inputs:
 
 - direct prompt, or
 - `--from-run <run-id>` to link build or deliver context
+
+Semantics:
+
+- standalone and intent-routed analysis prompts may run `review` in `analysis` mode
+- analysis mode records gap clusters, likely root causes, confidence, and recommended next slices
+- deliver-stage review remains `readiness` mode and continues to emit release-oriented `ready | changes-requested | blocked` outcomes
+- analysis-mode review runs complete successfully when the analysis succeeds, even if the findings are severe
+- delivery-gate phrasing such as `delivery is blocked` is reserved for readiness review, `ship`, and `deliver`
 
 Key artifacts:
 
@@ -436,6 +445,7 @@ Current inspector views include:
 - stages
 - specialists
 - artifacts
+- gaps
 - routing
 - research
 - session
@@ -448,8 +458,16 @@ Current inspector views include:
 - review
 - ship
 - GitHub mutation and delivery views
+- child-run drilldowns
 - delegate and artifact drilldowns
 - `what remains`
+
+Interactive inspector ergonomics:
+
+- tab completion for command names and common `show ...` targets
+- dynamic completion for stage names, specialist names, artifact paths, delegate tracks, and linked child stages
+- typo recovery with nearest-command suggestions
+- mode-aware review summaries so analysis runs show gaps and next slices while readiness runs show blocker/readiness state
 
 For failed `ship` and `deliver` runs, and for `review` verdicts that are `blocked` or `changes-requested`, the interactive inspector may also surface explicit mitigation commands. Those commands must derive their prompts from recorded artifacts, link the new run back to the inspected run, and switch the inspector to the newly started workflow once it exists.
 

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -152,6 +152,7 @@ export async function runReview(cwd: string, args: string[] = [], hooks: ReviewR
         `Run: ${runId}`,
         "Workflow: review",
         `Status: ${runRecord.status}`,
+        `Review mode: ${execution.reviewVerdict.mode}`,
         `Verdict: ${execution.reviewVerdict.status}`,
         "Artifacts:",
         `  ${path.relative(cwd, finalPath)}`,

--- a/src/deliver.ts
+++ b/src/deliver.ts
@@ -450,6 +450,7 @@ export async function runDeliverExecution(options: DeliverExecutionOptions): Pro
   const reviewLeadPrompt = await buildDeliverReviewLeadPrompt({
     cwd: options.cwd,
     input: options.input,
+    mode: "readiness",
     buildSummary: buildExecution.finalBody,
     verificationRecord: buildExecution.verificationRecord,
     validationPlan: validationExecution.validationPlan,

--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -32,6 +32,16 @@ interface InspectorCommandResponse {
   exit?: boolean;
 }
 
+interface InspectorCompletionContext {
+  commands: string[];
+  showTargets: string[];
+  stageNames: string[];
+  specialistNames: string[];
+  delegateTracks: string[];
+  artifactPaths: string[];
+  childStages: string[];
+}
+
 async function readRecentEvents(eventsPath?: string): Promise<RunEvent[]> {
   if (!eventsPath) {
     return [];
@@ -124,6 +134,36 @@ function renderSpecialistStrip(inspection: RunInspection): string {
   return planned.length > 0 ? planned.map((specialist) => badge(specialist.name, "plan")).join(" ") : "[none]";
 }
 
+function reviewMode(verdict: DeliverReviewVerdict | null): "analysis" | "readiness" {
+  if (verdict?.mode === "analysis") {
+    return "analysis";
+  }
+  return "readiness";
+}
+
+function renderReviewHeadline(verdict: DeliverReviewVerdict | null): string | undefined {
+  if (!verdict) {
+    return undefined;
+  }
+  return reviewMode(verdict) === "analysis" ? `- review mode: analysis (${verdict.status})` : `- review verdict: ${verdict.status}`;
+}
+
+function renderAnalysisReviewLines(verdict: DeliverReviewVerdict): string[] {
+  return [
+    `- analysis summary: ${verdict.summary}`,
+    ...(verdict.confidence ? [`- confidence: ${verdict.confidence}`] : []),
+    ...((verdict.gapClusters ?? []).slice(0, 4).map((cluster) => `- gap: ${cluster.title} [${cluster.severity}] ${cluster.summary}`)),
+    ...((verdict.recommendedNextSlices ?? []).slice(0, 3).map((slice) => `- next slice: ${slice}`))
+  ];
+}
+
+function renderReadinessReviewLines(verdict: DeliverReviewVerdict): string[] {
+  return [
+    `- review summary: ${verdict.summary}`,
+    ...verdict.recommendedActions.slice(0, 3).map((action) => `- action: ${action}`)
+  ];
+}
+
 function renderSuggestedActions(inspection: RunInspection): string[] {
   const lines: string[] = [];
   const deferredStages = inspection.stageLineage?.stages.filter((stage) => stage.status === "deferred" || stage.status === "skipped") ?? [];
@@ -156,6 +196,9 @@ function renderSuggestedActions(inspection: RunInspection): string[] {
   }
   if (inspection.run.workflow === "review") {
     lines.push("- inspect the review verdict with `show review`");
+    if (reviewMode(inspection.deliverReviewVerdict) === "analysis") {
+      lines.push("- inspect the main gap clusters with `gaps`");
+    }
     if (hasMitigationActions(inspection)) {
       lines.push("- review mitigation options with `show mitigations`");
       lines.push("- start the default mitigation workflow with `mitigate`");
@@ -186,6 +229,9 @@ function renderSuggestedActions(inspection: RunInspection): string[] {
   }
   if (inspection.artifacts.some((artifact) => artifact.path === "routing-plan.json")) {
     lines.push("- review routing with `show routing`");
+  }
+  if (inspection.childRuns.length > 0) {
+    lines.push(`- inspect linked child runs with \`show child ${inspection.childRuns[0]!.stageName}\``);
   }
 
   return lines.length > 0 ? lines : ["- no obvious follow-up recorded"];
@@ -663,6 +709,12 @@ function renderLineageSection(inspection: RunInspection): string[] {
 export function renderInspectionSummary(cwd: string, inspection: RunInspection): string {
   const { run, recentEvents, finalBody } = inspection;
   const failedChildRuns = inspection.childRuns.filter((child) => child.run.status === "failed");
+  const reviewDetails =
+    inspection.deliverReviewVerdict && reviewMode(inspection.deliverReviewVerdict) === "analysis"
+      ? renderAnalysisReviewLines(inspection.deliverReviewVerdict)
+      : inspection.deliverReviewVerdict
+        ? renderReadinessReviewLines(inspection.deliverReviewVerdict)
+        : [];
 
   return (
     [
@@ -683,7 +735,8 @@ export function renderInspectionSummary(cwd: string, inspection: RunInspection):
       inspection.verificationRecord ? `- verification: ${renderVerificationSummary(inspection.verificationRecord)}` : undefined,
       inspection.validationPlan ? `- validation: ${inspection.validationPlan.status}` : undefined,
       inspection.validationLocalRecord ? `- local validation: ${inspection.validationLocalRecord.status}` : undefined,
-      inspection.deliverReviewVerdict ? `- review verdict: ${inspection.deliverReviewVerdict.status}` : undefined,
+      renderReviewHeadline(inspection.deliverReviewVerdict),
+      ...reviewDetails,
       inspection.deliverShipRecord ? `- ship readiness: ${inspection.deliverShipRecord.readiness}` : undefined,
       inspection.githubMutationRecord ? `- github mutation: ${inspection.githubMutationRecord.summary}` : undefined,
       inspection.githubDeliveryRecord ? `- github delivery: ${renderGitHubSummary(inspection.githubDeliveryRecord)}` : undefined,
@@ -706,7 +759,7 @@ export function renderInspectionSummary(cwd: string, inspection: RunInspection):
       ...recentEvents.map((event) => `  [${event.type}] +${Math.floor(event.elapsedMs / 1000)}s ${event.message}`),
       "",
       "Shortcuts",
-      "- 1 summary  2 stages  3 specialists  4 artifacts  f final  r routing  q exit",
+      "- 1 summary  2 stages  3 specialists  4 artifacts  f final  r routing  g gaps  q exit",
       "",
       "Final output",
       finalBody || "(missing)"
@@ -777,6 +830,37 @@ async function renderValidationToolResearch(inspection: RunInspection): Promise<
 function renderDeliverReview(inspection: RunInspection): string {
   if (!inspection.deliverReviewVerdict) {
     return "No deliver review verdict was recorded for this run.";
+  }
+
+  if (reviewMode(inspection.deliverReviewVerdict) === "analysis") {
+    return [
+      "Analysis review:",
+      `- status: ${inspection.deliverReviewVerdict.status}`,
+      `- summary: ${inspection.deliverReviewVerdict.summary}`,
+      ...(inspection.deliverReviewVerdict.confidence ? [`- confidence: ${inspection.deliverReviewVerdict.confidence}`] : []),
+      "",
+      "Gap clusters:",
+      ...((inspection.deliverReviewVerdict.gapClusters ?? []).length > 0
+        ? (inspection.deliverReviewVerdict.gapClusters ?? []).map(
+            (cluster) => `- ${cluster.title} [${cluster.severity}]: ${cluster.summary}`
+          )
+        : ["- none recorded"]),
+      "",
+      "Likely root causes:",
+      ...((inspection.deliverReviewVerdict.likelyRootCauses ?? []).length > 0
+        ? (inspection.deliverReviewVerdict.likelyRootCauses ?? []).map((cause) => `- ${cause}`)
+        : ["- none recorded"]),
+      "",
+      "Recommended next slices:",
+      ...((inspection.deliverReviewVerdict.recommendedNextSlices ?? []).length > 0
+        ? (inspection.deliverReviewVerdict.recommendedNextSlices ?? []).map((slice) => `- ${slice}`)
+        : ["- none recorded"]),
+      "",
+      "Recommended actions:",
+      ...(inspection.deliverReviewVerdict.recommendedActions.length > 0
+        ? inspection.deliverReviewVerdict.recommendedActions.map((action) => `- ${action}`)
+        : ["- none recorded"])
+    ].join("\n");
   }
 
   return `${JSON.stringify(inspection.deliverReviewVerdict, null, 2)}\n`;
@@ -993,6 +1077,29 @@ function renderWhatRemains(inspection: RunInspection): string {
   return lines.join("\n");
 }
 
+function renderGapClusters(inspection: RunInspection): string {
+  if (!inspection.deliverReviewVerdict) {
+    return "No review verdict was recorded for this run.";
+  }
+  if (reviewMode(inspection.deliverReviewVerdict) !== "analysis") {
+    return "Gap clusters are only recorded for analysis-mode review runs.";
+  }
+
+  return [
+    "Gap clusters:",
+    ...((inspection.deliverReviewVerdict.gapClusters ?? []).length > 0
+      ? (inspection.deliverReviewVerdict.gapClusters ?? []).map(
+          (cluster) => `- ${cluster.title} [${cluster.severity}]: ${cluster.summary}`
+        )
+      : ["- none recorded"]),
+    "",
+    "Recommended next slices:",
+    ...((inspection.deliverReviewVerdict.recommendedNextSlices ?? []).length > 0
+      ? (inspection.deliverReviewVerdict.recommendedNextSlices ?? []).map((slice) => `- ${slice}`)
+      : ["- none recorded"])
+  ].join("\n");
+}
+
 function renderWhyDeferred(inspection: RunInspection, stageName: string): string {
   const stage = inspection.stageLineage?.stages.find((entry) => entry.name === stageName);
   if (!stage) {
@@ -1018,6 +1125,178 @@ async function readRelativeArtifact(inspection: RunInspection, relativePath: str
   }
 }
 
+function buildInspectorCompletionContext(inspection: RunInspection): InspectorCompletionContext {
+  const commands = [
+    "summary",
+    "stages",
+    "specialists",
+    "artifacts",
+    "gaps",
+    "show final",
+    "show routing",
+    "show research",
+    "show session",
+    "show verification",
+    "show validation",
+    "show pyramid",
+    "show coverage",
+    "show ci-validation",
+    "show tool-research",
+    "show review",
+    "show mitigations",
+    "show ship",
+    "show mutation",
+    "show github",
+    "show branch",
+    "show pr",
+    "show issues",
+    "show checks",
+    "show actions",
+    "show security",
+    "show release",
+    "show child",
+    "show delegate",
+    "show sources",
+    "show stage",
+    "show specialist",
+    "show artifact",
+    "why deferred",
+    "what remains",
+    "mitigate",
+    "resume",
+    "fork",
+    "help",
+    "exit",
+    "quit"
+  ];
+  const showTargets = [
+    "final",
+    "routing",
+    "research",
+    "session",
+    "verification",
+    "validation",
+    "pyramid",
+    "coverage",
+    "ci-validation",
+    "tool-research",
+    "review",
+    "mitigations",
+    "ship",
+    "mutation",
+    "github",
+    "branch",
+    "pr",
+    "issues",
+    "checks",
+    "actions",
+    "security",
+    "release",
+    "child",
+    "delegate",
+    "sources",
+    "stage",
+    "specialist",
+    "artifact"
+  ];
+
+  return {
+    commands,
+    showTargets,
+    stageNames: inspection.stageLineage?.stages.map((stage) => stage.name) ?? [],
+    specialistNames: [
+      ...(inspection.stageLineage?.specialists.map((specialist) => specialist.name) ?? []),
+      ...(inspection.routingPlan?.specialists.map((specialist) => specialist.name) ?? [])
+    ],
+    delegateTracks: inspection.discoverDelegates.map((delegate) => delegate.track),
+    artifactPaths: inspection.artifacts.map((artifact) => artifact.path),
+    childStages: inspection.childRuns.map((child) => child.stageName)
+  };
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].sort();
+}
+
+function completionMatches(values: string[], fragment: string): string[] {
+  const lowered = fragment.toLowerCase();
+  return uniqueSorted(values.filter((value) => value.toLowerCase().startsWith(lowered)));
+}
+
+export function completeInspectorInput(inspection: RunInspection, line: string): [string[], string] {
+  const trimmedStart = line.trimStart();
+  const context = buildInspectorCompletionContext(inspection);
+
+  if (trimmedStart.startsWith("show artifact ")) {
+    const fragment = trimmedStart.slice("show artifact ".length);
+    return [completionMatches(context.artifactPaths, fragment).map((match) => `show artifact ${match}`), line];
+  }
+  if (trimmedStart.startsWith("show stage ")) {
+    const fragment = trimmedStart.slice("show stage ".length);
+    return [completionMatches(context.stageNames, fragment).map((match) => `show stage ${match}`), line];
+  }
+  if (trimmedStart.startsWith("show specialist ")) {
+    const fragment = trimmedStart.slice("show specialist ".length);
+    return [completionMatches(context.specialistNames, fragment).map((match) => `show specialist ${match}`), line];
+  }
+  if (trimmedStart.startsWith("show delegate ")) {
+    const fragment = trimmedStart.slice("show delegate ".length);
+    return [completionMatches(context.delegateTracks, fragment).map((match) => `show delegate ${match}`), line];
+  }
+  if (trimmedStart.startsWith("show sources ")) {
+    const fragment = trimmedStart.slice("show sources ".length);
+    return [completionMatches(context.delegateTracks, fragment).map((match) => `show sources ${match}`), line];
+  }
+  if (trimmedStart.startsWith("show child ")) {
+    const fragment = trimmedStart.slice("show child ".length);
+    return [completionMatches(context.childStages, fragment).map((match) => `show child ${match}`), line];
+  }
+  if (trimmedStart.startsWith("show ")) {
+    const fragment = trimmedStart.slice("show ".length);
+    return [completionMatches(context.showTargets, fragment).map((match) => `show ${match}`), line];
+  }
+  if (trimmedStart.startsWith("why deferred ")) {
+    const fragment = trimmedStart.slice("why deferred ".length);
+    return [completionMatches(context.stageNames, fragment).map((match) => `why deferred ${match}`), line];
+  }
+
+  return [completionMatches(context.commands, trimmedStart), line];
+}
+
+function levenshteinDistance(a: string, b: string): number {
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  const matrix = Array.from({ length: rows }, () => new Array<number>(cols).fill(0));
+  for (let row = 0; row < rows; row += 1) {
+    matrix[row]![0] = row;
+  }
+  for (let col = 0; col < cols; col += 1) {
+    matrix[0]![col] = col;
+  }
+  for (let row = 1; row < rows; row += 1) {
+    for (let col = 1; col < cols; col += 1) {
+      const cost = a[row - 1] === b[col - 1] ? 0 : 1;
+      matrix[row]![col] = Math.min(
+        matrix[row - 1]![col]! + 1,
+        matrix[row]![col - 1]! + 1,
+        matrix[row - 1]![col - 1]! + cost
+      );
+    }
+  }
+  return matrix[rows - 1]![cols - 1]!;
+}
+
+function nearestInspectorCommands(inspection: RunInspection, input: string): string[] {
+  const context = buildInspectorCompletionContext(inspection);
+  const normalized = input.toLowerCase();
+  return uniqueSorted(context.commands)
+    .map((command) => ({ command, score: levenshteinDistance(normalized, command.toLowerCase()) }))
+    .sort((left, right) => left.score - right.score || left.command.localeCompare(right.command))
+    .slice(0, 3)
+    .filter((entry) => entry.score <= Math.max(3, Math.floor(normalized.length / 2)))
+    .map((entry) => entry.command);
+}
+
 function helpText(): string {
   return [
     "Inspector commands:",
@@ -1027,11 +1306,13 @@ function helpText(): string {
     "- 4 (artifacts)",
     "- f (show final)",
     "- r (show routing)",
+    "- g (gaps)",
     "- q (exit)",
     "- summary",
     "- stages",
     "- specialists",
     "- artifacts",
+    "- gaps",
     "- show final",
     "- show routing",
     "- show research",
@@ -1054,6 +1335,7 @@ function helpText(): string {
     "- show actions",
     "- show security",
     "- show release",
+    "- show child <stage>",
     "- show delegate <track>",
     "- show sources <track>",
     "- show stage <name>",
@@ -1089,6 +1371,9 @@ export async function executeInspectorCommand(cwd: string, inspection: RunInspec
   }
   if (trimmed === "4" || trimmed === "artifacts") {
     return { output: renderArtifacts(inspection) };
+  }
+  if (trimmed === "g" || trimmed === "gaps") {
+    return { output: renderGapClusters(inspection) };
   }
   if (trimmed === "f" || trimmed === "show final") {
     return { output: inspection.finalBody || "(missing)" };
@@ -1219,6 +1504,26 @@ export async function executeInspectorCommand(cwd: string, inspection: RunInspec
           .join("\n") + "\n"
     };
   }
+  if (trimmed.startsWith("show child ")) {
+    const stageName = trimmed.slice("show child ".length).trim();
+    const child = inspection.childRuns.find((entry) => entry.stageName === stageName);
+    if (!child) {
+      return { output: `No linked child run was recorded for stage \`${stageName}\`.` };
+    }
+    return {
+      output: [
+        `Child run for stage \`${stageName}\`:`,
+        `- run: ${child.run.id}`,
+        `- workflow: ${child.run.workflow}`,
+        `- status: ${child.run.status}`,
+        child.run.lastActivity ? `- last activity: ${child.run.lastActivity}` : undefined,
+        `- final: ${path.relative(cwd, child.run.finalPath)}`,
+        `- inspect child with: cstack inspect ${child.run.id}`
+      ]
+        .filter(Boolean)
+        .join("\n")
+    };
+  }
   if (trimmed.startsWith("show specialist ")) {
     const specialistName = trimmed.slice("show specialist ".length).trim();
     const specialist = inspection.stageLineage?.specialists.find((entry) => entry.name === specialistName);
@@ -1246,7 +1551,18 @@ export async function executeInspectorCommand(cwd: string, inspection: RunInspec
     return { output: await readRelativeArtifact(inspection, relativePath) };
   }
 
-  return { output: `Unknown inspector command: ${trimmed}\n\n${helpText()}` };
+  const suggestions = nearestInspectorCommands(inspection, trimmed);
+  return {
+    output: [
+      `Unknown inspector command: ${trimmed}`,
+      suggestions.length > 0 ? "" : undefined,
+      suggestions.length > 0 ? `Did you mean: ${suggestions.join(", ")}` : undefined,
+      "",
+      helpText()
+    ]
+      .filter((line) => line !== undefined)
+      .join("\n")
+  };
 }
 
 export async function handleInspectorCommand(cwd: string, inspection: RunInspection, input: string): Promise<string | null> {
@@ -1266,14 +1582,15 @@ export async function runInteractiveInspector(
     throw new Error("Interactive inspection requires a TTY.");
   }
 
+  let currentInspection = inspection;
   const rl = readline.createInterface({
     input: io.input,
     output: io.output,
-    terminal: true
+    terminal: true,
+    completer: (line) => completeInspectorInput(currentInspection, line)
   });
 
   try {
-    let currentInspection = inspection;
     io.output.write("Entering cstack run inspector. Type `help` for commands.\n");
     io.output.write(renderInspectionSummary(cwd, currentInspection));
     while (true) {

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -7,6 +7,7 @@ import type {
   DiscoverDelegateResult,
   DiscoverResearchPlan,
   DiscoverTrackName,
+  ReviewMode,
   RoutingPlan,
   SpecialistName,
   ValidationRepoProfile,
@@ -439,33 +440,61 @@ export async function buildSpecialistPrompt(options: {
 export async function buildDeliverReviewLeadPrompt(options: {
   cwd: string;
   input: string;
+  mode: ReviewMode;
   buildSummary: string;
   verificationRecord: object;
   validationPlan?: object;
   validationLocalRecord?: object;
   specialistResults: Array<{ name: SpecialistName; reason: string; finalBody: string }>;
 }): Promise<{ prompt: string; context: string }> {
-  const { cwd, input, buildSummary, verificationRecord, validationPlan, validationLocalRecord, specialistResults } = options;
+  const { cwd, input, mode, buildSummary, verificationRecord, validationPlan, validationLocalRecord, specialistResults } = options;
   const specDoc = path.join(cwd, "docs", "specs", "cstack-spec-v0.1.md");
 
   return {
     prompt: [
-      "You are the `Review Lead` for a bounded `cstack deliver` workflow.",
+      mode === "analysis"
+        ? "You are the `Review Lead` for a bounded `cstack review` workflow running in analysis mode."
+        : "You are the `Review Lead` for a bounded `cstack deliver` workflow.",
       "",
-      "Synthesize the build stage output, verification evidence, and specialist reviews into one review verdict.",
+      mode === "analysis"
+        ? "Synthesize the linked context, evidence, and specialist reviews into one analytical gap assessment."
+        : "Synthesize the build stage output, verification evidence, and specialist reviews into one review verdict.",
       "",
       "Requirements:",
-      "- be explicit about whether delivery is ready, needs changes, or is blocked",
-      "- preserve serious risks even when the build itself completed",
+      ...(mode === "analysis"
+        ? [
+            "- treat this as analytical critique, not as a release gate",
+            "- identify the main gap clusters, likely root causes, and next implementation slices",
+            "- use `status: \"completed\"` when the analysis succeeded, even if the findings are severe",
+            "- do not phrase the summary as `delivery is blocked` unless the user explicitly asked for readiness"
+          ]
+        : [
+            "- be explicit about whether delivery is ready, needs changes, or is blocked",
+            "- preserve serious risks even when the build itself completed"
+          ]),
       "- cite specialist input only when it materially changed the verdict",
       "- return valid JSON only, with no markdown fences or extra commentary",
       "",
       "Required JSON shape:",
       "{",
-      '  "status": "ready" | "changes-requested" | "blocked",',
+      mode === "analysis"
+        ? '  "mode": "analysis",'
+        : '  "mode": "readiness",',
+      mode === "analysis"
+        ? '  "status": "completed",'
+        : '  "status": "ready" | "changes-requested" | "blocked",',
       '  "summary": "short summary",',
       '  "findings": [{"severity": "info" | "warning" | "high", "title": "finding title", "detail": "details", "owner": "optional"}],',
       '  "recommendedActions": ["action"],',
+      ...(mode === "analysis"
+        ? [
+            '  "gapClusters": [{"title": "gap cluster", "severity": "info" | "warning" | "high", "summary": "what is missing", "evidence": ["optional evidence"]}],',
+            '  "likelyRootCauses": ["cause"],',
+            '  "recommendedNextSlices": ["next slice"],',
+            '  "confidence": "low" | "medium" | "high",',
+            '  "evidenceNotes": ["evidence note"],'
+          ]
+        : []),
       '  "acceptedSpecialists": [{"name": "security-review", "disposition": "accepted" | "partial" | "discarded", "reason": "why"}],',
       '  "reportMarkdown": "# Review Findings\\n..."',
       "}",
@@ -492,8 +521,9 @@ export async function buildDeliverReviewLeadPrompt(options: {
       `- ${specDoc}`
     ].join("\n"),
     context: [
-      "Workflow: deliver",
+      `Workflow: ${mode === "analysis" ? "review" : "deliver"}`,
       "Role: Review Lead",
+      `Review mode: ${mode}`,
       `Selected specialists: ${specialistResults.map((result) => result.name).join(", ") || "none"}`,
       `Spec source: ${specDoc}`
     ].join("\n")

--- a/src/review.ts
+++ b/src/review.ts
@@ -10,6 +10,7 @@ import type {
   DeliverValidationLocalRecord,
   DeliverValidationPlan,
   DeliverReviewVerdict,
+  ReviewMode,
   SpecialistExecution,
   SpecialistSelection,
   StageLineage,
@@ -80,6 +81,45 @@ function parseJson<T>(raw: string, context: string): T {
 
 function selectedSpecialistsForInput(input: string): SpecialistSelection[] {
   return inferRoutingPlan(input, "run").specialists.filter((specialist) => specialist.selected).slice(0, 3);
+}
+
+function inferReviewMode(input: string, linkedContext?: LinkedReviewContext): ReviewMode {
+  if (linkedContext?.workflow === "deliver") {
+    return "readiness";
+  }
+
+  const normalized = input.toLowerCase();
+  const analysisSignals = [
+    "what are the gaps",
+    "gaps in this project",
+    "gaps in the current project",
+    "what is missing",
+    "what's missing",
+    "assess the current state",
+    "assess current state",
+    "key risks",
+    "current risks",
+    "evaluate the current state"
+  ];
+  const readinessSignals = [
+    "ready for release",
+    "release ready",
+    "ship ready",
+    "delivery ready",
+    "ready to ship",
+    "ready to merge",
+    "release readiness",
+    "delivery readiness"
+  ];
+
+  if (readinessSignals.some((signal) => normalized.includes(signal))) {
+    return "readiness";
+  }
+  if (analysisSignals.some((signal) => normalized.includes(signal))) {
+    return "analysis";
+  }
+
+  return linkedContext ? "readiness" : "analysis";
 }
 
 async function runReviewSpecialist(options: {
@@ -166,10 +206,29 @@ async function runReviewSpecialist(options: {
 
 function buildFinalSummary(options: {
   input: string;
+  reviewMode: ReviewMode;
   linkedContext?: LinkedReviewContext;
   stageLineage: StageLineage;
   reviewVerdict: DeliverReviewVerdict;
 }): string {
+  const verdictLines =
+    options.reviewMode === "analysis"
+      ? [
+          `- mode: ${options.reviewVerdict.mode}`,
+          `- status: ${options.reviewVerdict.status}`,
+          `- summary: ${options.reviewVerdict.summary}`,
+          ...(options.reviewVerdict.gapClusters ?? []).map(
+            (cluster) => `- gap: ${cluster.title} [${cluster.severity}] ${cluster.summary}`
+          ),
+          ...((options.reviewVerdict.recommendedNextSlices ?? []).map((slice) => `- next slice: ${slice}`))
+        ]
+      : [
+          `- mode: ${options.reviewVerdict.mode}`,
+          `- status: ${options.reviewVerdict.status}`,
+          `- summary: ${options.reviewVerdict.summary}`,
+          ...options.reviewVerdict.recommendedActions.map((action) => `- action: ${action}`)
+        ];
+
   return [
     "# Review Run Summary",
     "",
@@ -190,9 +249,7 @@ function buildFinalSummary(options: {
       : ["- none"]),
     "",
     "## Verdict",
-    `- status: ${options.reviewVerdict.status}`,
-    `- summary: ${options.reviewVerdict.summary}`,
-    ...options.reviewVerdict.recommendedActions.map((action) => `- action: ${action}`)
+    ...verdictLines
   ].join("\n") + "\n";
 }
 
@@ -252,6 +309,7 @@ export async function resolveLinkedReviewContext(cwd: string, runId: string): Pr
 
 export async function runReviewExecution(options: ReviewExecutionOptions): Promise<ReviewExecutionResult> {
   const selectedSpecialists = selectedSpecialistsForInput(options.input);
+  const reviewMode = inferReviewMode(options.input, options.linkedContext);
   const linkedContext = options.linkedContext;
   const stageLineage: StageLineage = {
     intent: options.input,
@@ -293,6 +351,7 @@ export async function runReviewExecution(options: ReviewExecutionOptions): Promi
   const reviewPrompt = await buildDeliverReviewLeadPrompt({
     cwd: options.cwd,
     input: options.input,
+    mode: reviewMode,
     buildSummary,
     verificationRecord,
     ...(linkedContext?.validationPlan ? { validationPlan: linkedContext.validationPlan } : {}),
@@ -352,6 +411,7 @@ export async function runReviewExecution(options: ReviewExecutionOptions): Promi
 
   const finalBody = buildFinalSummary({
     input: options.input,
+    reviewMode,
     stageLineage,
     reviewVerdict,
     ...(linkedContext ? { linkedContext } : {})

--- a/src/ship.ts
+++ b/src/ship.ts
@@ -111,6 +111,7 @@ function notRunVerificationRecord(): BuildVerificationRecord {
 
 function blockedReviewVerdict(summary: string): DeliverReviewVerdict {
   return {
+    mode: "readiness",
     status: "blocked",
     summary,
     findings: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -324,11 +324,26 @@ export interface DeliverReviewFinding {
   owner?: string;
 }
 
+export type ReviewMode = "analysis" | "readiness";
+
+export interface DeliverReviewGapCluster {
+  title: string;
+  severity: "info" | "warning" | "high";
+  summary: string;
+  evidence?: string[];
+}
+
 export interface DeliverReviewVerdict {
-  status: "ready" | "changes-requested" | "blocked";
+  mode: ReviewMode;
+  status: "completed" | "ready" | "changes-requested" | "blocked";
   summary: string;
   findings: DeliverReviewFinding[];
   recommendedActions: string[];
+  gapClusters?: DeliverReviewGapCluster[];
+  likelyRootCauses?: string[];
+  recommendedNextSlices?: string[];
+  confidence?: "low" | "medium" | "high";
+  evidenceNotes?: string[];
   acceptedSpecialists: Array<{
     name: SpecialistName;
     disposition: SpecialistDisposition;

--- a/test/fixtures/fake-codex.mjs
+++ b/test/fixtures/fake-codex.mjs
@@ -216,49 +216,78 @@ if (prompt.includes("track in a bounded `cstack discover` research run")) {
     "",
     "No blocking gaps detected in the fake fixture."
   ].join("\n");
+} else if (prompt.includes("You are the `Review Lead` for a bounded `cstack review` workflow running in analysis mode.")) {
+  body = JSON.stringify(
+    {
+      mode: "analysis",
+      status: "completed",
+      summary: "Gap analysis completed. High-priority product and delivery gaps remain.",
+      findings: [
+        {
+          severity: "high",
+          title: "Contract drift",
+          detail: "The shipped interfaces and the planned contract are no longer aligned."
+        },
+        {
+          severity: "warning",
+          title: "Validation evidence missing",
+          detail: "There is no runnable end-to-end evidence attached to this review path."
+        }
+      ],
+      recommendedActions: [
+        "Align the repo on one source of truth for API routes and ingest semantics.",
+        "Add verification evidence before treating the project as release-ready."
+      ],
+      gapClusters: [
+        {
+          title: "Contract drift",
+          severity: "high",
+          summary: "The API, connector, and documented behavior no longer describe the same system.",
+          evidence: ["spec drift", "connector mismatch"]
+        },
+        {
+          title: "Validation gap",
+          severity: "high",
+          summary: "The repo lacks runnable end-to-end or contract validation evidence for the advertised behavior.",
+          evidence: ["missing verification artifacts"]
+        }
+      ],
+      likelyRootCauses: [
+        "Contract updates and implementation changes are landing through different paths.",
+        "Validation expectations are not encoded as a required workflow gate."
+      ],
+      recommendedNextSlices: [
+        "Define and align one API contract across code, docs, and clients.",
+        "Add runnable verification for the main ingest and metadata flows."
+      ],
+      confidence: "high",
+      evidenceNotes: ["Fake fixture inferred gaps from the linked prompt contract."],
+      acceptedSpecialists: [],
+      reportMarkdown: "# Review Findings\n\nGap analysis completed.\n"
+    },
+    null,
+    2
+  );
 } else if (prompt.includes("You are the `Review Lead` for a bounded `cstack deliver` workflow.")) {
-  if (/what are the gaps/i.test(prompt)) {
-    body = JSON.stringify(
-      {
-        status: "blocked",
-        summary: "Major contract, behavior, and process gaps remain unresolved.",
-        findings: [
-          {
-            severity: "error",
-            title: "Contract drift",
-            detail: "The shipped interfaces and the planned contract are no longer aligned."
-          }
-        ],
-        recommendedActions: [
-          "Define a single source of truth for the API contract.",
-          "Add verification evidence before treating the project as delivery-ready."
-        ],
-        acceptedSpecialists: [],
-        reportMarkdown: "# Review Findings\n\nMajor gaps remain unresolved.\n"
-      },
-      null,
-      2
-    );
-  } else {
-    body = JSON.stringify(
-      {
-        status: "ready",
-        summary: "Review completed with bounded follow-up.",
-        findings: [
-          {
-            severity: "warning",
-            title: "Release readiness follow-up",
-            detail: "Review the release checklist before merge."
-          }
-        ],
-        recommendedActions: ["Review the release checklist before merge."],
-        acceptedSpecialists: [],
-        reportMarkdown: "# Review Findings\n\nBounded follow-up required.\n"
-      },
-      null,
-      2
-    );
-  }
+  body = JSON.stringify(
+    {
+      mode: "readiness",
+      status: "ready",
+      summary: "Review completed with bounded follow-up.",
+      findings: [
+        {
+          severity: "warning",
+          title: "Release readiness follow-up",
+          detail: "Review the release checklist before merge."
+        }
+      ],
+      recommendedActions: ["Review the release checklist before merge."],
+      acceptedSpecialists: [],
+      reportMarkdown: "# Review Findings\n\nBounded follow-up required.\n"
+    },
+    null,
+    2
+  );
 } else if (prompt.includes("You are the `Ship Lead` for a bounded `cstack deliver` workflow.")) {
   body = JSON.stringify(
     {

--- a/test/inspect.test.ts
+++ b/test/inspect.test.ts
@@ -6,7 +6,7 @@ import { promises as fs } from "node:fs";
 import { chmodSync } from "node:fs";
 import { promisify } from "node:util";
 import { runInspect } from "../src/commands/inspect.js";
-import { executeInspectorCommand, handleInspectorCommand, loadRunInspection, runInteractiveInspector } from "../src/inspector.js";
+import { completeInspectorInput, executeInspectorCommand, handleInspectorCommand, loadRunInspection, runInteractiveInspector } from "../src/inspector.js";
 import type { RoutingPlan, RunEvent, RunRecord, StageLineage } from "../src/types.js";
 
 const execFileAsync = promisify(execFile);
@@ -481,7 +481,7 @@ async function seedReviewRun(repoDir: string): Promise<string> {
     workflow: "review",
     createdAt: "2026-03-15T05:36:07.000Z",
     updatedAt: "2026-03-15T05:36:38.070Z",
-    status: "failed",
+    status: "completed",
     cwd: repoDir,
     gitBranch: "main",
     codexVersion: "fake",
@@ -493,9 +493,8 @@ async function seedReviewRun(repoDir: string): Promise<string> {
     stdoutPath: path.join(runDir, "stdout.log"),
     stderrPath: path.join(runDir, "stderr.log"),
     configSources: [],
-    lastActivity: "Delivery is not ready. The repo has unresolved contract, runtime, and configuration gaps, and there is no verification evidence for this review run.",
+    lastActivity: "Gap analysis completed. High-priority product and delivery gaps remain.",
     summary: "What are the gaps in the current project",
-    error: "Delivery is not ready. The repo has unresolved contract, runtime, and configuration gaps, and there is no verification evidence for this review run.",
     inputs: {
       userPrompt: "What are the gaps in the current project",
       linkedRunId: "2026-03-15T05-28-16-672Z-intent-what-are-the-gaps-in-the-current-project"
@@ -503,13 +502,13 @@ async function seedReviewRun(repoDir: string): Promise<string> {
   };
 
   await fs.writeFile(path.join(runDir, "run.json"), `${JSON.stringify(run, null, 2)}\n`, "utf8");
-  await fs.writeFile(path.join(runDir, "final.md"), "# Review Run Summary\n\nChanges requested.\n", "utf8");
+  await fs.writeFile(path.join(runDir, "final.md"), "# Review Run Summary\n\nGap analysis completed.\n", "utf8");
   await fs.writeFile(
     path.join(runDir, "stage-lineage.json"),
     `${JSON.stringify(
       {
         intent: "What are the gaps in the current project",
-        stages: [{ name: "review", rationale: "Critique current readiness.", status: "completed", executed: true }],
+        stages: [{ name: "review", rationale: "Analyze the main gaps and risks.", status: "completed", executed: true }],
         specialists: []
       },
       null,
@@ -521,16 +520,43 @@ async function seedReviewRun(repoDir: string): Promise<string> {
     path.join(runDir, "artifacts", "verdict.json"),
     `${JSON.stringify(
       {
-        status: "changes-requested",
-        summary:
-          "Delivery is not ready. The repo has unresolved contract, runtime, and configuration gaps, and there is no verification evidence for this review run.",
-        findings: [],
+        mode: "analysis",
+        status: "completed",
+        summary: "Gap analysis completed. High-priority product and delivery gaps remain.",
+        findings: [
+          {
+            severity: "high",
+            title: "Contract drift",
+            detail: "API behavior, docs, and connector expectations no longer line up."
+          }
+        ],
         recommendedActions: [
           "Choose one source of truth for API routes, status codes, and ingest/heartbeat semantics, then align API code, Java clients, integration tests, and docs to it.",
           "Run the intended API, CLI, and connector verification commands and attach the results to the next review."
         ],
+        gapClusters: [
+          {
+            title: "Contract drift",
+            severity: "high",
+            summary: "The API, docs, and connector behavior disagree on key runtime semantics."
+          },
+          {
+            title: "Validation gap",
+            severity: "high",
+            summary: "There is no runnable end-to-end evidence for the advertised metadata path."
+          }
+        ],
+        likelyRootCauses: [
+          "Contract changes are not flowing through one source of truth.",
+          "Validation requirements are not enforced before review."
+        ],
+        recommendedNextSlices: [
+          "Align the API contract across code, docs, and client surfaces.",
+          "Add runnable verification for ingest and metadata flows."
+        ],
+        confidence: "high",
         acceptedSpecialists: [],
-        reportMarkdown: "# Review Findings\n\nChanges requested.\n"
+        reportMarkdown: "# Review Findings\n\nGap analysis completed.\n"
       },
       null,
       2
@@ -538,7 +564,7 @@ async function seedReviewRun(repoDir: string): Promise<string> {
     "utf8"
   );
 
-  await fs.writeFile(path.join(runDir, "artifacts", "findings.md"), "# Review Findings\n\nChanges requested.\n", "utf8");
+  await fs.writeFile(path.join(runDir, "artifacts", "findings.md"), "# Review Findings\n\nGap analysis completed.\n", "utf8");
   await fs.writeFile(
     path.join(runDir, "artifacts", "findings.json"),
     `${JSON.stringify(
@@ -797,6 +823,7 @@ async function seedDeliverRun(
     path.join(runDir, "stages", "review", "artifacts", "verdict.json"),
     `${JSON.stringify(
       {
+        mode: "readiness",
         status: "changes-requested",
         summary: "Review completed with bounded follow-up.",
         findings: [],
@@ -1207,14 +1234,40 @@ describe("inspect", () => {
     }
   });
 
+  it("renders analysis-mode review summaries and gap commands for review runs", async () => {
+    const reviewRunId = await seedReviewRun(repoDir);
+    const inspection = await loadRunInspection(repoDir, reviewRunId);
+
+    expect(inspection.deliverReviewVerdict?.mode).toBe("analysis");
+    await expect(handleInspectorCommand(repoDir, inspection, "1")).resolves.toContain("review mode: analysis");
+    await expect(handleInspectorCommand(repoDir, inspection, "1")).resolves.toContain("gap: Contract drift");
+    await expect(handleInspectorCommand(repoDir, inspection, "show review")).resolves.toContain("Analysis review:");
+    await expect(handleInspectorCommand(repoDir, inspection, "gaps")).resolves.toContain("Gap clusters:");
+    await expect(handleInspectorCommand(repoDir, inspection, "gaps")).resolves.toContain("Recommended next slices:");
+  });
+
+  it("offers completion and suggestions in the interactive inspector model", async () => {
+    const reviewRunId = await seedReviewRun(repoDir);
+    const reviewInspection = await loadRunInspection(repoDir, reviewRunId);
+    const intentRunId = await seedIntentFailedReviewRun(repoDir);
+    const intentInspection = await loadRunInspection(repoDir, intentRunId);
+
+    expect(completeInspectorInput(reviewInspection, "sho")[0]).toContain("show final");
+    expect(completeInspectorInput(reviewInspection, "show st")[0]).toContain("show stage");
+    expect(completeInspectorInput(reviewInspection, "show stage re")[0]).toContain("show stage review");
+    expect(completeInspectorInput(reviewInspection, "show artifact arti")[0]).toContain("show artifact artifacts/verdict.json");
+    await expect(handleInspectorCommand(reviewInspection.run.cwd, reviewInspection, "artifatcs")).resolves.toContain("Did you mean:");
+    await expect(handleInspectorCommand(intentInspection.run.cwd, intentInspection, "show child review")).resolves.toContain("run:");
+  });
+
   it("surfaces downstream review failure context from a parent intent run", async () => {
     const failedIntentRunId = await seedIntentFailedReviewRun(repoDir);
     const inspection = await loadRunInspection(repoDir, failedIntentRunId);
 
     expect(inspection.childRuns).toHaveLength(1);
     expect(inspection.childRuns[0]?.run.workflow).toBe("review");
-    await expect(handleInspectorCommand(repoDir, inspection, "1")).resolves.toContain("downstream review failed");
-    await expect(handleInspectorCommand(repoDir, inspection, "1")).resolves.toContain("inspect child run: cstack inspect");
+    await expect(handleInspectorCommand(repoDir, inspection, "1")).resolves.toContain("Intent run finished with downstream workflow failures");
+    await expect(handleInspectorCommand(repoDir, inspection, "1")).resolves.toContain("inspect linked child runs with `show child review`");
     await expect(handleInspectorCommand(repoDir, inspection, "artifacts")).resolves.toContain("Linked child runs:");
     await expect(handleInspectorCommand(repoDir, inspection, "artifacts")).resolves.toContain("artifacts/verdict.json");
     await expect(handleInspectorCommand(repoDir, inspection, "show stage review")).resolves.toContain("Linked child run:");

--- a/test/intent.test.ts
+++ b/test/intent.test.ts
@@ -182,16 +182,20 @@ describe("intent router", () => {
     const reviewRunDir = path.dirname(reviewRun.finalPath);
     const lineage = JSON.parse(await fs.readFile(path.join(intentRunDir, "stage-lineage.json"), "utf8")) as StageLineage;
     const reviewVerdict = JSON.parse(await fs.readFile(path.join(reviewRunDir, "artifacts", "verdict.json"), "utf8")) as {
+      mode: string;
       status: string;
       summary: string;
+      gapClusters?: Array<{ title: string }>;
     };
 
     expect(intentRun.status).toBe("completed");
     expect(intentRun.error).toBeUndefined();
     expect(reviewRun.status).toBe("completed");
-    expect(reviewVerdict.status).toBe("blocked");
+    expect(reviewVerdict.mode).toBe("analysis");
+    expect(reviewVerdict.status).toBe("completed");
+    expect(reviewVerdict.gapClusters?.[0]?.title).toBe("Contract drift");
     expect(lineage.stages.find((stage) => stage.name === "review")?.status).toBe("completed");
-    expect(await fs.readFile(intentRun.finalPath, "utf8")).toContain("Major contract, behavior, and process gaps remain unresolved.");
+    expect(await fs.readFile(intentRun.finalPath, "utf8")).toContain("Gap analysis completed. High-priority product and delivery gaps remain.");
   });
 
   it("supports dry-run routing without executing stages", async () => {

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -106,6 +106,7 @@ describe("runReview", () => {
       const run = await readRun(repoDir, reviewRun!.id);
       const runDir = path.dirname(run.finalPath);
       const verdict = JSON.parse(await fs.readFile(path.join(runDir, "artifacts", "verdict.json"), "utf8")) as {
+        mode: string;
         status: string;
         summary: string;
       };
@@ -114,6 +115,7 @@ describe("runReview", () => {
 
       expect(run.inputs.linkedRunId).toBe(buildRunId);
       expect(run.status).toBe("completed");
+      expect(verdict.mode).toBe("readiness");
       expect(verdict.status).toBe("ready");
       expect(findings).toContain("Review Findings");
       expect(lineage.stages[0]?.name).toBe("review");
@@ -171,14 +173,18 @@ describe("runReview", () => {
       const run = await readRun(repoDir, reviewRun!.id);
       const runDir = path.dirname(run.finalPath);
       const verdict = JSON.parse(await fs.readFile(path.join(runDir, "artifacts", "verdict.json"), "utf8")) as {
+        mode: string;
         status: string;
         summary: string;
+        gapClusters?: Array<{ title: string }>;
       };
 
       expect(run.status).toBe("completed");
       expect(run.error).toBeUndefined();
-      expect(verdict.status).toBe("blocked");
-      expect(stdoutSpy.mock.calls.map(([chunk]) => String(chunk)).join("")).toContain("Verdict: blocked");
+      expect(verdict.mode).toBe("analysis");
+      expect(verdict.status).toBe("completed");
+      expect(verdict.gapClusters?.[0]?.title).toBe("Contract drift");
+      expect(stdoutSpy.mock.calls.map(([chunk]) => String(chunk)).join("")).toContain("Review mode: analysis");
     } finally {
       stdoutSpy.mockRestore();
     }

--- a/test/ship.test.ts
+++ b/test/ship.test.ts
@@ -94,6 +94,7 @@ async function seedReviewRun(repoDir: string, buildRunId: string): Promise<strin
   };
 
   const verdict: DeliverReviewVerdict = {
+    mode: "readiness",
     status: "ready",
     summary: "Review passed.",
     findings: [],


### PR DESCRIPTION
## Summary
- split review semantics so analysis-style prompts produce analysis-mode review artifacts instead of delivery-gate phrasing
- upgrade `cstack inspect --interactive` with completion, suggestions, `gaps`, and child-run drilldowns
- update spec, README, fixtures, and regression coverage for the new review contract

## What changed
- add `mode` and analysis fields to the review verdict contract
- run standalone and intent-routed gap-analysis prompts in `analysis` mode while keeping deliver review in `readiness` mode
- render analysis-mode review summaries in the inspector with gap clusters, confidence, and recommended next slices
- add readline completion for commands, stages, specialists, artifacts, delegate tracks, and child stages
- add nearest-command suggestions and `show child <stage>` / `gaps` inspector commands

## Validation
- `npm run typecheck`
- `npm test`
- `npm run build`
- focused gap-analysis path validated through tests and a local temp-workspace smoke on the built CLI

## Notes
- I also probed the exact prompt against `/tmp/sqlite-metadata-proposal`; it still sits in broad `discover` for a long time, which looks like a separate routing/perf issue rather than a semantics or inspect UX issue.
