### PR TITLE
fix: route broad gap analysis directly to review

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,13 +152,13 @@ What it does today:
 - accepts a natural-language task
 - infers an internal stage plan
 - persists `routing-plan.json` and `stage-lineage.json`
-- executes `discover` and `spec` inside one orchestrated run
 - auto-executes downstream `review`, `ship`, or `deliver` when the inferred plan warrants it
 - keeps bounded specialist reviews inside the intent run only when the router stops after planning
 
 Current intent behavior:
 
-- `discover` and `spec` are executed automatically inside the intent run
+- implementation and planning prompts still execute `discover` and `spec` automatically inside the intent run
+- broad analysis prompts like `What are the gaps in this project` can route directly to downstream `review` to avoid paying full planning overhead first
 - review-shaped analysis prompts auto-run standalone `review`
 - implementation-shaped prompts auto-run `deliver`, which carries the work through internal `build -> validation -> review -> ship`
 - explicit `build`, `review`, `ship`, and `deliver` commands still exist when you want a narrower workflow than the routed front door

--- a/docs/specs/cstack-spec-v0.1.md
+++ b/docs/specs/cstack-spec-v0.1.md
@@ -251,14 +251,13 @@ Current intent behavior:
 - infer a stage plan
 - persist `routing-plan.json`
 - persist `stage-lineage.json`
-- execute `discover`
-- execute `spec`
 - auto-execute downstream `review`, `ship`, or `deliver` when the inferred plan warrants it
 - keep bounded specialist reviews inside the intent run only when the router stops after planning
 
 The active intent contract is:
 
-- plan and execute deterministic planning stages first
+- broad analysis prompts may route directly into downstream `review` when planning overhead is unlikely to add value
+- implementation and planning prompts still execute deterministic `discover` and `spec` stages first
 - auto-carry analysis prompts into `review`
 - auto-carry implementation prompts into `deliver`
 - preserve child workflow lineage in the parent intent run

--- a/src/intent.ts
+++ b/src/intent.ts
@@ -61,8 +61,42 @@ function ensureUniqueStages(stages: RoutingStagePlan[]): RoutingStagePlan[] {
   });
 }
 
+function hasImplementationIntent(lower: string): boolean {
+  return /\b(add|build|implement|fix|refactor|migrate|introduce|create|change|update|close|resolve)\b/i.test(lower);
+}
+
+function hasReviewIntent(lower: string): boolean {
+  return /\b(review|audit|security|compliance|traceability|verify|check|gap|gaps|missing|assess|assessment|evaluate|evaluation)\b/i.test(lower);
+}
+
+function hasReleaseIntent(lower: string): boolean {
+  return /\b(release|ship|deploy|rollout|pipeline|version)\b/i.test(lower);
+}
+
+function isBroadAnalysisPrompt(lower: string): boolean {
+  return (
+    /\b(what are the gaps|gaps in (this|the current) project|what is missing|what's missing|assess (the )?current state|evaluate (the )?current state|key risks)\b/i.test(
+      lower
+    ) &&
+    !hasImplementationIntent(lower) &&
+    !hasReleaseIntent(lower)
+  );
+}
+
 function inferStagePlans(intent: string): RoutingStagePlan[] {
   const lower = intent.toLowerCase();
+
+  if (isBroadAnalysisPrompt(lower)) {
+    return [
+      {
+        name: "review",
+        rationale: "The intent is broad gap analysis, so route directly to analytical review instead of paying planning overhead first.",
+        status: "planned",
+        executed: false
+      }
+    ];
+  }
+
   const stages: RoutingStagePlan[] = [
     {
       name: "discover",
@@ -78,7 +112,7 @@ function inferStagePlans(intent: string): RoutingStagePlan[] {
     }
   ];
 
-  if (/\b(add|build|implement|fix|refactor|migrate|introduce|create|change|update|close|resolve)\b/i.test(lower)) {
+  if (hasImplementationIntent(lower)) {
     stages.push({
       name: "build",
       rationale: "The intent implies implementation work after planning.",
@@ -99,7 +133,7 @@ function inferStagePlans(intent: string): RoutingStagePlan[] {
     });
   }
 
-  if (/\b(review|audit|security|compliance|traceability|verify|check|gap|gaps|missing|assess|assessment|evaluate|evaluation)\b/i.test(lower)) {
+  if (hasReviewIntent(lower)) {
     stages.push({
       name: "review",
       rationale: "The intent carries explicit review or risk-checking language.",
@@ -108,7 +142,7 @@ function inferStagePlans(intent: string): RoutingStagePlan[] {
     });
   }
 
-  if (/\b(release|ship|deploy|rollout|pipeline|version)\b/i.test(lower)) {
+  if (hasReleaseIntent(lower)) {
     stages.push({
       name: "ship",
       rationale: "The intent mentions release or rollout concerns.",

--- a/test/intent.test.ts
+++ b/test/intent.test.ts
@@ -65,9 +65,9 @@ describe("intent router", () => {
     ]);
   });
 
-  it("routes gap-analysis prompts into review after planning", () => {
+  it("routes broad gap-analysis prompts directly into review", () => {
     const plan = inferRoutingPlan("What are the gaps in the current project?", "bare");
-    expect(plan.stages.map((stage) => stage.name)).toEqual(["discover", "spec", "review"]);
+    expect(plan.stages.map((stage) => stage.name)).toEqual(["review"]);
   });
 
   it("creates an intent run and auto-executes downstream delivery when the inferred plan warrants it", async () => {
@@ -156,11 +156,14 @@ describe("intent router", () => {
 
     expect(intentRun.status).toBe("completed");
     expect(intentRun.sessionId).toBe(reviewRun.sessionId);
+    expect(lineage.stages.map((stage) => stage.name)).toEqual(["review"]);
     expect(lineage.stages.find((stage) => stage.name === "review")?.status).toBe("completed");
     expect(lineage.stages.find((stage) => stage.name === "review")?.childRunId).toBe(reviewRun.id);
     expect(eventsBody).toContain("Running downstream review workflow from intent");
     expect(eventsBody).toContain(`Downstream review run ${reviewRun.id} started`);
     expect(eventsBody).toContain("Downstream review stage: review");
+    expect(eventsBody).not.toContain("Running discover stage");
+    expect(eventsBody).not.toContain("Running spec stage");
   });
 
   it("keeps intent completed when downstream review finds blocked gaps", async () => {
@@ -194,6 +197,7 @@ describe("intent router", () => {
     expect(reviewVerdict.mode).toBe("analysis");
     expect(reviewVerdict.status).toBe("completed");
     expect(reviewVerdict.gapClusters?.[0]?.title).toBe("Contract drift");
+    expect(lineage.stages.map((stage) => stage.name)).toEqual(["review"]);
     expect(lineage.stages.find((stage) => stage.name === "review")?.status).toBe("completed");
     expect(await fs.readFile(intentRun.finalPath, "utf8")).toContain("Gap analysis completed. High-priority product and delivery gaps remain.");
   });


### PR DESCRIPTION
## Summary
- route broad gap-analysis prompts directly to downstream `review`
- avoid paying `discover` + `spec` planning overhead for prompts like `What are the gaps in this project`
- update the active spec, README, and intent tests to reflect the narrowed analysis path

## What changed
- added intent heuristics for broad analysis prompts with no implementation or release intent
- these prompts now infer `review` as the only stage
- implementation and planning prompts still keep the existing `discover` / `spec` path

## Validation
- `npm run typecheck`
- `npm test`
- `npm run build`
- exact prompt validated in `/tmp/sqlite-metadata-proposal` with the local built CLI:
  - before: entered `discover -> spec -> review`
  - after: enters `review` immediately

## Why
The prompt `cstack "What are the gaps in this project"` is asking for critique, not planning or implementation. On larger repos the old path looked hung because it forced broad discover/spec work before review even started.
