### PR TITLE
fix: route gap-closure prompts through delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Current intent behavior:
 
 - implementation and planning prompts still execute `discover` and `spec` automatically inside the intent run
 - broad analysis prompts like `What are the gaps in this project` can route directly to downstream `review` to avoid paying full planning overhead first
+- mixed prompts that also ask `cstack` to close or remediate the gaps stay on the implementation path and continue through planning and delivery stages
 - review-shaped analysis prompts auto-run standalone `review`
 - implementation-shaped prompts auto-run `deliver`, which carries the work through internal `build -> validation -> review -> ship`
 - explicit `build`, `review`, `ship`, and `deliver` commands still exist when you want a narrower workflow than the routed front door

--- a/docs/specs/cstack-spec-v0.1.md
+++ b/docs/specs/cstack-spec-v0.1.md
@@ -257,6 +257,7 @@ Current intent behavior:
 The active intent contract is:
 
 - broad analysis prompts may route directly into downstream `review` when planning overhead is unlikely to add value
+- mixed prompts that combine gap analysis with explicit remediation or closure intent should stay on the implementation path and continue through `discover`, `spec`, and downstream delivery stages
 - implementation and planning prompts still execute deterministic `discover` and `spec` stages first
 - auto-carry analysis prompts into `review`
 - auto-carry implementation prompts into `deliver`

--- a/src/intent.ts
+++ b/src/intent.ts
@@ -62,7 +62,11 @@ function ensureUniqueStages(stages: RoutingStagePlan[]): RoutingStagePlan[] {
 }
 
 function hasImplementationIntent(lower: string): boolean {
-  return /\b(add|build|implement|fix|refactor|migrate|introduce|create|change|update|close|resolve)\b/i.test(lower);
+  return (
+    /\b(add|build|implement|fix|refactor|migrate|introduce|create|change|update|close|closing|resolve|address|remediate)\b/i.test(
+      lower
+    ) || /\bwork on\b/i.test(lower)
+  );
 }
 
 function hasReviewIntent(lower: string): boolean {

--- a/test/intent.test.ts
+++ b/test/intent.test.ts
@@ -70,6 +70,11 @@ describe("intent router", () => {
     expect(plan.stages.map((stage) => stage.name)).toEqual(["review"]);
   });
 
+  it("routes gap-analysis prompts with explicit remediation intent into delivery stages", () => {
+    const plan = inferRoutingPlan("What are the gaps in this project? Can you work on closing the gaps?", "bare");
+    expect(plan.stages.map((stage) => stage.name)).toEqual(["discover", "spec", "build", "review", "ship"]);
+  });
+
   it("creates an intent run and auto-executes downstream delivery when the inferred plan warrants it", async () => {
     const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     try {
@@ -200,6 +205,32 @@ describe("intent router", () => {
     expect(lineage.stages.map((stage) => stage.name)).toEqual(["review"]);
     expect(lineage.stages.find((stage) => stage.name === "review")?.status).toBe("completed");
     expect(await fs.readFile(intentRun.finalPath, "utf8")).toContain("Gap analysis completed. High-priority product and delivery gaps remain.");
+  });
+
+  it("auto-executes downstream delivery for gap-analysis prompts that also ask for remediation", async () => {
+    await runIntent(repoDir, "What are the gaps in this project? Can you work on closing the gaps?", {
+      entrypoint: "bare",
+      dryRun: false
+    });
+
+    const runs = await listRuns(repoDir);
+    expect(runs.map((run) => run.workflow).sort()).toEqual(["deliver", "intent"]);
+
+    const intentRun = await readRun(
+      repoDir,
+      runs.find((entry) => entry.workflow === "intent")!.id
+    );
+    const deliverRun = await readRun(
+      repoDir,
+      runs.find((entry) => entry.workflow === "deliver")!.id
+    );
+    const intentRunDir = path.dirname(intentRun.finalPath);
+    const lineage = JSON.parse(await fs.readFile(path.join(intentRunDir, "stage-lineage.json"), "utf8")) as StageLineage;
+
+    expect(intentRun.status).toBe("completed");
+    expect(deliverRun.status).toBe("completed");
+    expect(lineage.stages.map((stage) => stage.name)).toEqual(["discover", "spec", "build", "review", "ship"]);
+    expect(lineage.stages.find((stage) => stage.name === "build")?.childRunId).toBe(deliverRun.id);
   });
 
   it("supports dry-run routing without executing stages", async () => {


### PR DESCRIPTION
## Summary
- keep pure broad gap-analysis prompts on the fast `review` path
- route mixed prompts that ask to close/remediate the gaps back through delivery
- add regression tests for the exact prompt shape and document the routing rule

## Validation
- npx vitest run test/intent.test.ts
- npm run typecheck
- npm run build
- local smoke in `/tmp/sqlite-metadata-proposal` with:
  - `cstack "What are the gaps in this project? Can you work on closing the gaps?"`
  - verified `Inferred stages: discover -> spec -> build -> review -> ship`
