### PR TITLE
feat: render tty stages as breadcrumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ While a run is active in a normal terminal, `cstack` renders a bounded ANSI dash
 The live dashboard shows:
 
 - a header with workflow, run id, status, current stage, live elapsed time, and session
-- a stage strip
+- a stage breadcrumb path
 - a specialist strip when relevant
 - a single live progress line that summarizes current stdout/stderr/heartbeat signals
 - a visible pulse/liveness indicator so you know the run is still moving

--- a/docs/specs/cstack-spec-v0.1.md
+++ b/docs/specs/cstack-spec-v0.1.md
@@ -371,6 +371,7 @@ The elapsed counter must not remain static during active execution. A repaint-on
 The body must show at minimum:
 
 - a stage progress strip
+- a stable stage breadcrumb path in fixed order
 - a specialist strip when relevant
 - a single live progress line that summarizes current stdout/stderr/heartbeat signals
 - a fixed-height recent milestones pane

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -120,6 +120,24 @@ function compactName(input: string): string {
   return input.replace(/-/g, " ");
 }
 
+function breadcrumbStatusLabel(status: DashboardStatus): string {
+  switch (status) {
+    case "completed":
+      return "done";
+    case "failed":
+      return "fail";
+    case "running":
+      return "live";
+    case "deferred":
+      return "defer";
+    case "skipped":
+      return "skip";
+    case "pending":
+    default:
+      return "plan";
+  }
+}
+
 function shortRunId(input: string): string {
   return input.length > 28 ? `${input.slice(0, 12)}…${input.slice(-12)}` : input;
 }
@@ -508,10 +526,10 @@ export class ProgressReporter {
             : "waiting for the current step to finish"
     }`;
     const stageLine =
-      this.stages.length > 0 ? `${colorize("Stages", ANSI.bold, this.colorsEnabled)} ${this.renderItems(this.stages)}` : undefined;
+      this.stages.length > 0 ? `${colorize("Path", ANSI.bold, this.colorsEnabled)} ${this.renderBreadcrumbs(this.stages)}` : undefined;
     const specialistLine =
       this.specialists.length > 0
-        ? `${colorize("Specialists", ANSI.bold, this.colorsEnabled)} ${this.renderItems(this.specialists)}`
+        ? `${colorize("Specialists", ANSI.bold, this.colorsEnabled)} ${this.renderSpecialists(this.specialists)}`
         : undefined;
     const activityHeader = colorize("Recent milestones", ANSI.bold, this.colorsEnabled);
     const activityLines = this.history
@@ -548,7 +566,19 @@ export class ProgressReporter {
     ].filter(Boolean) as string[];
   }
 
-  private renderItems(items: DashboardItem[]): string {
+  private renderBreadcrumbs(items: DashboardItem[]): string {
+    return items
+      .map((item) => {
+        const icon = statusIcon(item.status);
+        const label = compactName(item.name);
+        const suffix = breadcrumbStatusLabel(item.status);
+        return colorize(`${icon} ${label}`, statusColor(item.status), this.colorsEnabled) +
+          colorize(` (${suffix})`, ANSI.dim, this.colorsEnabled);
+      })
+      .join(colorize("  ›  ", ANSI.gray, this.colorsEnabled));
+  }
+
+  private renderSpecialists(items: DashboardItem[]): string {
     return items
       .map((item) => {
         const label = `${statusIcon(item.status)} ${compactName(item.name)}:${statusLabel(item.status)}`;

--- a/test/progress.test.ts
+++ b/test/progress.test.ts
@@ -74,8 +74,9 @@ describe("ProgressReporter", () => {
 
     const output = stream.writes.join("");
     expect(output).toContain("\u001B[?25l");
-    expect(output).toContain("Stages");
-    expect(output).toContain("✅ discover:done");
+    expect(output).toContain("Path");
+    expect(output).toContain("✅ discover");
+    expect(output).toContain("(done)");
     expect(output).toContain("Progress");
     expect(output).toContain("Next");
     expect(output).toContain("Recent milestones");
@@ -169,6 +170,8 @@ describe("ProgressReporter", () => {
 
     expect(output).toContain("Progress");
     expect(output).toContain("Recent milestones");
+    expect(output).toContain("Path");
+    expect(output).toContain("discover (live)  ›  ⏳ spec (plan)  ›  ⏳ review (plan)");
     expect(output).toContain("[+0:00] Routing intent across discover -> spec -> review");
     expect(output).toContain("[+0:00] Running discover stage");
     expect(output).toContain("…");


### PR DESCRIPTION
## Summary
- replace the flickery stage chips with a steadier breadcrumb path
- keep stage ordering fixed and show status inline per stage
- preserve the single progress line and fixed-height milestones pane

## Validation
- npx vitest run test/progress.test.ts
- npm run typecheck
- npm test
- npm run build
- tty smoke: `script -qec 'node ./bin/cstack.js update --check' /tmp/cstack-breadcrumb-smoke.txt`
