### PR TITLE
feat: classify github delivery failures

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -33,6 +33,13 @@ interface CommandResult {
   stderr: string;
 }
 
+interface CommandFailureDetails {
+  message: string;
+  stderr: string;
+  stdout: string;
+  combined: string;
+}
+
 export interface CollectGitHubDeliveryOptions {
   cwd: string;
   gitBranch: string;
@@ -112,6 +119,69 @@ async function runGit(cwd: string, args: string[]): Promise<CommandResult> {
 
 async function runGh(command: string, cwd: string, args: string[]): Promise<CommandResult> {
   return runCommand(command, args, cwd);
+}
+
+function commandFailureDetails(error: unknown): CommandFailureDetails {
+  const candidate = error as {
+    message?: unknown;
+    stderr?: unknown;
+    stdout?: unknown;
+    code?: unknown;
+  };
+  const message = typeof candidate?.message === "string" ? candidate.message.trim() : String(error);
+  const stderr = typeof candidate?.stderr === "string" ? candidate.stderr.trim() : "";
+  const stdout = typeof candidate?.stdout === "string" ? candidate.stdout.trim() : "";
+  const combined = [stderr, stdout, message].filter(Boolean).join("\n").trim();
+  return {
+    message,
+    stderr,
+    stdout,
+    combined: combined || message
+  };
+}
+
+function classifyGitHubFailure(action: string, error: unknown): { summary: string; detail: string } {
+  const detail = commandFailureDetails(error).combined;
+  const normalized = detail.toLowerCase();
+
+  if (
+    /\b(auth|authenticate|authentication|not logged in|login)\b/.test(normalized) ||
+    /\b401\b/.test(normalized) ||
+    /\b403\b/.test(normalized)
+  ) {
+    return {
+      summary: `GitHub authentication failed while ${action}.`,
+      detail
+    };
+  }
+
+  if (/\b(rate limit|secondary rate limit)\b/.test(normalized) || /\b429\b/.test(normalized)) {
+    return {
+      summary: `GitHub rate limiting blocked ${action}.`,
+      detail
+    };
+  }
+
+  if (
+    /\b(econnreset|econnrefused|enotfound|network|timeout|timed out|tls|connection reset|temporary failure)\b/.test(normalized)
+  ) {
+    return {
+      summary: `GitHub connectivity failed while ${action}.`,
+      detail
+    };
+  }
+
+  if (/\bnot found\b/.test(normalized) || /\b404\b/.test(normalized)) {
+    return {
+      summary: `GitHub returned not-found while ${action}.`,
+      detail
+    };
+  }
+
+  return {
+    summary: `GitHub failed while ${action}.`,
+    detail
+  };
 }
 
 function parseGitHubRepository(remoteUrl: string): string | null {
@@ -439,14 +509,15 @@ async function detectPullRequest(options: {
       blockers
     );
   } catch (error) {
+    const failure = classifyGitHubFailure("resolving the pull request", error);
     return gate(
       prRequired,
       prRequired ? "blocked" : "not-applicable",
-      prRequired ? "A pull request is required but none could be resolved for the current branch." : "Pull request checks were not required.",
+      prRequired ? failure.summary : "Pull request checks were not required.",
       null,
       "gh",
-      prRequired ? ["No pull request could be resolved for the current branch."] : [],
-      error instanceof Error ? error.message : String(error)
+      prRequired ? [failure.summary] : [],
+      failure.detail
     );
   }
 }
@@ -500,16 +571,15 @@ async function detectIssues(options: {
         blockers.push(`Issue #${raw.number} is ${raw.state} but closed issues are required.`);
       }
     } catch (error) {
-      blockers.push(`Issue #${number} could not be inspected.`);
+      const failure = classifyGitHubFailure(`inspecting issue #${number}`, error);
+      blockers.push(failure.summary);
       issues.push({
         number,
         title: `Issue #${number}`,
         state: "UNKNOWN",
         url: ""
       });
-      if (error instanceof Error) {
-        blockers.push(error.message);
-      }
+      blockers.push(failure.detail);
     }
   }
 
@@ -598,14 +668,15 @@ async function detectChecks(options: {
       blockers
     );
   } catch (error) {
+    const failure = classifyGitHubFailure("inspecting required checks", error);
     return gate(
       required,
       required ? "blocked" : "not-applicable",
-      required ? "Required checks could not be inspected." : "Checks were not required for this deliver run.",
+      required ? failure.summary : "Checks were not required for this deliver run.",
       [],
       "gh",
-      required ? ["Required checks could not be inspected."] : [],
-      error instanceof Error ? error.message : String(error)
+      required ? [failure.summary] : [],
+      failure.detail
     );
   }
 }
@@ -688,14 +759,15 @@ async function detectActions(options: {
       blockers
     );
   } catch (error) {
+    const failure = classifyGitHubFailure("inspecting GitHub Actions workflow runs", error);
     return gate(
       true,
       "blocked",
-      "Required GitHub Actions workflows could not be inspected.",
+      failure.summary,
       [],
       "gh",
-      ["Required GitHub Actions workflows could not be inspected."],
-      error instanceof Error ? error.message : String(error)
+      [failure.summary],
+      failure.detail
     );
   }
 }
@@ -759,8 +831,9 @@ async function detectSecurity(options: {
         }
       }
     } catch (error) {
-      blockers.push("Dependabot alerts could not be inspected.");
-      return gate(required, "blocked", "Dependabot alerts could not be inspected.", { dependabot, codeScanning }, "gh", blockers, error instanceof Error ? error.message : String(error));
+      const failure = classifyGitHubFailure("inspecting Dependabot alerts", error);
+      blockers.push(failure.summary);
+      return gate(required, "blocked", failure.summary, { dependabot, codeScanning }, "gh", blockers, failure.detail);
     }
   }
 
@@ -784,8 +857,9 @@ async function detectSecurity(options: {
         }
       }
     } catch (error) {
-      blockers.push("Code scanning alerts could not be inspected.");
-      return gate(required, "blocked", "Code scanning alerts could not be inspected.", { dependabot, codeScanning }, "gh", blockers, error instanceof Error ? error.message : String(error));
+      const failure = classifyGitHubFailure("inspecting code scanning alerts", error);
+      blockers.push(failure.summary);
+      return gate(required, "blocked", failure.summary, { dependabot, codeScanning }, "gh", blockers, failure.detail);
     }
   }
 
@@ -885,6 +959,7 @@ async function detectRelease(options: {
       blockers
     );
   } catch (error) {
+    const failure = classifyGitHubFailure(`inspecting GitHub release ${expectedTag}`, error);
     const release: GitHubReleaseRecord = {
       tagName: expectedTag,
       version: packageVersion,
@@ -893,7 +968,7 @@ async function detectRelease(options: {
       releaseExists: false
     };
     if (requireRelease) {
-      blockers.push(`GitHub release ${expectedTag} was not found.`);
+      blockers.push(failure.summary);
     }
     return gate(
       true,
@@ -902,7 +977,7 @@ async function detectRelease(options: {
       release,
       requireRelease ? "gh" : "git",
       blockers,
-      error instanceof Error ? error.message : String(error)
+      failure.detail
     );
   }
 }
@@ -1066,7 +1141,9 @@ export async function performGitHubDeliverMutations(options: PerformGitHubMutati
           pullRequestUpdated = true;
         }
       } catch (error) {
-        blockers.push(`Failed to create or update the pull request: ${error instanceof Error ? error.message : String(error)}`);
+        const failure = classifyGitHubFailure("creating or updating the pull request", error);
+        blockers.push(failure.summary);
+        blockers.push(failure.detail);
       }
 
       try {
@@ -1078,7 +1155,9 @@ export async function performGitHubDeliverMutations(options: PerformGitHubMutati
         });
       } catch (error) {
         if (policy.createPullRequest || policy.updatePullRequest) {
-          blockers.push(`Failed to load pull request state after mutation: ${error instanceof Error ? error.message : String(error)}`);
+          const failure = classifyGitHubFailure("loading pull request state after mutation", error);
+          blockers.push(failure.summary);
+          blockers.push(failure.detail);
         }
       }
     }

--- a/test/deliver.test.ts
+++ b/test/deliver.test.ts
@@ -560,10 +560,97 @@ describe("runDeliver", () => {
     expect(run.status).toBe("failed");
     expect(githubMutation.pullRequest.created).toBe(false);
     expect(githubMutation.pullRequest.updated).toBe(false);
-    expect(githubMutation.summary).toContain("Failed to create or update the pull request");
+    expect(githubMutation.summary).toContain("GitHub failed while creating or updating the pull request.");
     expect(githubMutation.blockers.join("\n")).toContain("simulated PR create failure");
     expect(githubDelivery.pullRequest.status).toBe("blocked");
     expect(githubDelivery.overall.status).toBe("blocked");
+    expect(githubDelivery.overall.blockers.join("\n")).toContain("GitHub failed while creating or updating the pull request.");
     expect(githubDelivery.overall.blockers.join("\n")).toContain("simulated PR create failure");
+  });
+
+  it("classifies GitHub authentication failures during pull request creation", async () => {
+    await writeGitHubFixture({
+      repoView: {
+        nameWithOwner: "ganesh47/cstack",
+        defaultBranchRef: { name: "main" }
+      },
+      prCreateError: "HTTP 401: authentication required. Run gh auth login.",
+      issues: [
+        {
+          number: 902,
+          title: "Auth failure issue",
+          state: "CLOSED",
+          url: "https://github.com/ganesh47/cstack/issues/902",
+          closedAt: "2026-03-14T00:00:00.000Z"
+        }
+      ],
+      prChecks: [],
+      actions: [],
+      security: {
+        dependabot: [],
+        codeScanning: []
+      }
+    });
+
+    await runDeliver(repoDir, ["Deliver a fix that will hit GitHub auth failure for #902"]);
+
+    const runs = await listRuns(repoDir);
+    const run = await readRun(repoDir, runs[0]!.id);
+    const runDir = path.dirname(run.finalPath);
+    const githubMutation = JSON.parse(await fs.readFile(path.join(runDir, "artifacts", "github-mutation.json"), "utf8")) as {
+      blockers: string[];
+      summary: string;
+    };
+
+    expect(run.status).toBe("failed");
+    expect(githubMutation.summary).toContain("GitHub authentication failed while creating or updating the pull request.");
+    expect(githubMutation.blockers.join("\n")).toContain("Run gh auth login");
+  });
+
+  it("classifies GitHub connectivity failures during required check inspection", async () => {
+    await writeGitHubFixture({
+      repoView: {
+        nameWithOwner: "ganesh47/cstack",
+        defaultBranchRef: { name: "main" }
+      },
+      createdPullRequest: {
+        reviewDecision: "APPROVED",
+        mergeStateStatus: "CLEAN"
+      },
+      issues: [
+        {
+          number: 903,
+          title: "Checks connectivity issue",
+          state: "CLOSED",
+          url: "https://github.com/ganesh47/cstack/issues/903",
+          closedAt: "2026-03-14T00:00:00.000Z"
+        }
+      ],
+      prChecksError: "network timeout contacting api.github.com",
+      actions: [
+        { databaseId: 1, workflowName: "Release", status: "completed", conclusion: "success", url: "https://github.com/ganesh47/cstack/actions/runs/1" }
+      ],
+      security: {
+        dependabot: [],
+        codeScanning: []
+      }
+    });
+
+    await runDeliver(repoDir, ["Deliver a fix that will hit required-check network failure for #903"]);
+
+    const runs = await listRuns(repoDir);
+    const run = await readRun(repoDir, runs[0]!.id);
+    const runDir = path.dirname(run.finalPath);
+    const githubDelivery = JSON.parse(await fs.readFile(path.join(runDir, "artifacts", "github-delivery.json"), "utf8")) as {
+      checks: { status: string; summary: string; error?: string };
+      overall: { status: string; blockers: string[] };
+    };
+
+    expect(run.status).toBe("failed");
+    expect(githubDelivery.checks.status).toBe("blocked");
+    expect(githubDelivery.checks.summary).toContain("GitHub connectivity failed while inspecting required checks.");
+    expect(githubDelivery.checks.error).toContain("network timeout contacting api.github.com");
+    expect(githubDelivery.overall.status).toBe("blocked");
+    expect(githubDelivery.overall.blockers.join("\n")).toContain("GitHub connectivity failed while inspecting required checks.");
   });
 });

--- a/test/fixtures/fake-gh.mjs
+++ b/test/fixtures/fake-gh.mjs
@@ -126,6 +126,9 @@ if (args[0] === "pr" && args[1] === "edit") {
 }
 
 if (args[0] === "pr" && args[1] === "checks") {
+  if (fixture.prChecksError) {
+    fail(fixture.prChecksError);
+  }
   printJson(fixture.prChecks ?? fixture.checks ?? []);
   process.exit(0);
 }
@@ -147,6 +150,9 @@ if (args[0] === "issue" && args[1] === "view") {
 }
 
 if (args[0] === "run" && args[1] === "list") {
+  if (fixture.actionsError) {
+    fail(fixture.actionsError);
+  }
   printJson(fixture.actions ?? []);
   process.exit(0);
 }
@@ -187,6 +193,9 @@ if (args[0] === "api") {
     process.exit(0);
   }
   if (/^repos\/.+$/.test(endpoint)) {
+    if (fixture.repoApiError) {
+      fail(fixture.repoApiError);
+    }
     printJson({ default_branch: fixture.repoView?.defaultBranchRef?.name ?? "main" });
     process.exit(0);
   }


### PR DESCRIPTION
## Summary
- classify common `gh` external failures into clearer operator-facing summaries
- preserve raw `gh` stderr details in delivery artifacts instead of collapsing everything into generic failure text
- add regression coverage for PR mutation auth failures and required-check inspection connectivity failures

## Validation
- npm test -- test/deliver.test.ts
- npm run typecheck
- npm test
- npm run build
- /home/ganesh/projects/cstack/bin/cstack.js runs --recent 3 (in /tmp/sqlite-metadata-proposal)
- /home/ganesh/projects/cstack/bin/cstack.js inspect 2026-03-16T12-49-00-888Z-intent-what-are-the-gaps-in-this-project-can-you-work-o (in /tmp/sqlite-metadata-proposal)
