### PR TITLE
feat: harden github mutation failure reporting

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -235,6 +235,37 @@ async function detectDefaultBranch(ghCommand: string, cwd: string, repository: s
   }
 }
 
+function classifyGitFailure(action: string, error: unknown): { summary: string; detail: string } {
+  const detail = commandFailureDetails(error).combined;
+  const normalized = detail.toLowerCase();
+
+  if (/\b(rejected|non-fast-forward|failed to push some refs|protected branch)\b/.test(normalized)) {
+    return {
+      summary: `Git rejected the push while ${action}.`,
+      detail
+    };
+  }
+
+  if (/\b(not a git repository|could not read from remote repository|repository not found|no such remote)\b/.test(normalized)) {
+    return {
+      summary: `Git could not reach the configured remote while ${action}.`,
+      detail
+    };
+  }
+
+  if (/\b(already exists|would be overwritten by checkout)\b/.test(normalized)) {
+    return {
+      summary: `Git could not prepare the working branch while ${action}.`,
+      detail
+    };
+  }
+
+  return {
+    summary: `Git failed while ${action}.`,
+    detail
+  };
+}
+
 async function readPackageVersion(cwd: string): Promise<string | null> {
   try {
     const body = await fs.readFile(path.join(cwd, "package.json"), "utf8");
@@ -1048,7 +1079,9 @@ export async function performGitHubDeliverMutations(options: PerformGitHubMutati
       createdBranch = true;
     }
   } catch (error) {
-    blockers.push(`Failed to create branch ${branch}: ${error instanceof Error ? error.message : String(error)}`);
+    const failure = classifyGitFailure(`creating branch ${branch}`, error);
+    blockers.push(failure.summary);
+    blockers.push(failure.detail);
   }
 
   if (policy.commitChanges && blockers.length === 0) {
@@ -1064,7 +1097,9 @@ export async function performGitHubDeliverMutations(options: PerformGitHubMutati
         commitCreated = true;
         commitSha = await currentHeadSha(options.cwd);
       } catch (error) {
-        blockers.push(`Failed to commit deliver changes: ${error instanceof Error ? error.message : String(error)}`);
+        const failure = classifyGitFailure("creating the deliver commit", error);
+        blockers.push(failure.summary);
+        blockers.push(failure.detail);
       }
     }
   }
@@ -1077,7 +1112,9 @@ export async function performGitHubDeliverMutations(options: PerformGitHubMutati
         await runGit(options.cwd, ["push", "--set-upstream", remote, branch]);
         pushed = true;
       } catch (error) {
-        blockers.push(`Failed to push branch ${branch}: ${error instanceof Error ? error.message : String(error)}`);
+        const failure = classifyGitFailure(`pushing branch ${branch}`, error);
+        blockers.push(failure.summary);
+        blockers.push(failure.detail);
       }
     }
   }

--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -604,6 +604,10 @@ function renderGitHubSummary(record: GitHubDeliveryRecord | null): string {
   if (blockingGates.length === 0) {
     return record.overall.status;
   }
+  const firstBlocker = record.overall.blockers[0]?.replace(/\s+/g, " ").trim();
+  if (firstBlocker) {
+    return `${record.overall.status} (${blockingGates.join(", ")}: ${firstBlocker})`;
+  }
   return `${record.overall.status} (${blockingGates.join(", ")})`;
 }
 

--- a/test/deliver.test.ts
+++ b/test/deliver.test.ts
@@ -653,4 +653,108 @@ describe("runDeliver", () => {
     expect(githubDelivery.overall.status).toBe("blocked");
     expect(githubDelivery.overall.blockers.join("\n")).toContain("GitHub connectivity failed while inspecting required checks.");
   });
+
+  it("classifies git push rejection during deliver mutations", async () => {
+    await writeGitHubFixture({
+      repoView: {
+        nameWithOwner: "ganesh47/cstack",
+        defaultBranchRef: { name: "main" }
+      },
+      createdPullRequest: {
+        reviewDecision: "APPROVED",
+        mergeStateStatus: "CLEAN"
+      },
+      issues: [
+        {
+          number: 904,
+          title: "Push rejection issue",
+          state: "CLOSED",
+          url: "https://github.com/ganesh47/cstack/issues/904",
+          closedAt: "2026-03-14T00:00:00.000Z"
+        }
+      ],
+      prChecks: [],
+      actions: [],
+      security: {
+        dependabot: [],
+        codeScanning: []
+      }
+    });
+
+    const hookPath = path.join(remoteDir, "hooks", "pre-receive");
+    await fs.writeFile(
+      hookPath,
+      "#!/bin/sh\n" +
+        "echo 'remote rejected: protected branch hook declined' >&2\n" +
+        "exit 1\n",
+      "utf8"
+    );
+    chmodSync(hookPath, 0o755);
+
+    await runDeliver(repoDir, ["Deliver a fix that will hit git push rejection for #904"]);
+
+    const runs = await listRuns(repoDir);
+    const run = await readRun(repoDir, runs[0]!.id);
+    const runDir = path.dirname(run.finalPath);
+    const githubMutation = JSON.parse(await fs.readFile(path.join(runDir, "artifacts", "github-mutation.json"), "utf8")) as {
+      summary: string;
+      blockers: string[];
+      branch: { pushed: boolean };
+    };
+
+    expect(run.status).toBe("failed");
+    expect(githubMutation.branch.pushed).toBe(false);
+    expect(githubMutation.summary).toContain("Git rejected the push while pushing branch");
+    expect(githubMutation.blockers.join("\n")).toContain("protected branch hook declined");
+  });
+
+  it("classifies GitHub pull request update conflicts", async () => {
+    await writeGitHubFixture({
+      repoView: {
+        nameWithOwner: "ganesh47/cstack",
+        defaultBranchRef: { name: "main" }
+      },
+      pullRequest: {
+        number: 44,
+        title: "Existing PR",
+        state: "OPEN",
+        isDraft: false,
+        reviewDecision: "APPROVED",
+        url: "https://github.com/ganesh47/cstack/pull/44",
+        headRefName: "cstack/existing-branch",
+        baseRefName: "main",
+        mergeStateStatus: "CLEAN"
+      },
+      prEditError: "GraphQL: Update failed because the pull request was modified concurrently",
+      issues: [
+        {
+          number: 905,
+          title: "PR conflict issue",
+          state: "CLOSED",
+          url: "https://github.com/ganesh47/cstack/issues/905",
+          closedAt: "2026-03-14T00:00:00.000Z"
+        }
+      ],
+      prChecks: [],
+      actions: [],
+      security: {
+        dependabot: [],
+        codeScanning: []
+      }
+    });
+
+    await runDeliver(repoDir, ["Deliver a fix that will hit PR update conflict for #905"]);
+
+    const runs = await listRuns(repoDir);
+    const run = await readRun(repoDir, runs[0]!.id);
+    const runDir = path.dirname(run.finalPath);
+    const githubMutation = JSON.parse(await fs.readFile(path.join(runDir, "artifacts", "github-mutation.json"), "utf8")) as {
+      summary: string;
+      blockers: string[];
+    };
+
+    expect(run.status).toBe("failed");
+    expect(githubMutation.summary).toContain("GitHub failed while creating or updating the pull request.");
+    expect(githubMutation.blockers.join("\n")).toContain("modified concurrently");
+  });
 });

--- a/test/inspect.test.ts
+++ b/test/inspect.test.ts
@@ -1370,7 +1370,7 @@ describe("inspect", () => {
     await expect(handleInspectorCommand(repoDir, inspection, "1")).resolves.toContain("ship readiness: blocked");
     await expect(handleInspectorCommand(repoDir, inspection, "1")).resolves.toContain("validation: partial");
     await expect(handleInspectorCommand(repoDir, inspection, "1")).resolves.toContain("github mutation: Branch pushed and pull request prepared.");
-    await expect(handleInspectorCommand(repoDir, inspection, "1")).resolves.toContain("github delivery: blocked (checks, security)");
+    await expect(handleInspectorCommand(repoDir, inspection, "1")).resolves.toContain("github delivery: blocked (checks, security: Required check deliver/test is failing.)");
   });
 
   it("shows ready GitHub delivery details for ready deliver runs", async () => {


### PR DESCRIPTION
## Summary
- classify git-side mutation failures like push rejection more explicitly
- cover PR update conflict paths in addition to PR create failures
- surface the first blocked GitHub gate reason more aggressively in top-level inspect summaries

## Validation
- npm test -- test/deliver.test.ts test/inspect.test.ts
- npm run typecheck
- npm test
- npm run build
- /home/ganesh/projects/cstack/bin/cstack.js inspect 2026-03-16T12-49-00-888Z-intent-what-are-the-gaps-in-this-project-can-you-work-o (in /tmp/sqlite-metadata-proposal)
