### PR TITLE
feat: explain intent routing decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Current intent behavior:
 - implementation and planning prompts still execute `discover` and `spec` automatically inside the intent run
 - broad analysis prompts like `What are the gaps in this project` can route directly to downstream `review` to avoid paying full planning overhead first
 - mixed prompts that also ask `cstack` to close or remediate the gaps stay on the implementation path and continue through planning and delivery stages
+- `routing-plan.json` now records both the winning routing decision and the matched prompt signals so `cstack inspect` can explain why a broad or mixed prompt took its chosen path
 - review-shaped analysis prompts auto-run standalone `review`
 - implementation-shaped prompts auto-run `deliver`, which carries the work through internal `build -> validation -> review -> ship`
 - explicit `build`, `review`, `ship`, and `deliver` commands still exist when you want a narrower workflow than the routed front door

--- a/docs/specs/cstack-spec-v0.1.md
+++ b/docs/specs/cstack-spec-v0.1.md
@@ -276,6 +276,7 @@ The active intent contract is:
 - implementation and planning prompts still execute deterministic `discover` and `spec` stages first
 - auto-carry analysis prompts into `review`
 - auto-carry implementation prompts into `deliver`
+- persist enough routing decision metadata for `inspect` to explain which prompt signals caused analysis-only versus implementation-capable routing
 - preserve child workflow lineage in the parent intent run
 
 ## GitHub-Scoped Engineering Delivery

--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -963,6 +963,25 @@ function renderRoutingSection(inspection: RunInspection): string[] {
   return [
     "",
     `Routing plan: ${path.relative(inspection.run.cwd, path.join(inspection.runDir, "routing-plan.json"))}`,
+    ...(routingPlan.decision
+      ? [
+          `Decision: ${routingPlan.decision.classification}`,
+          `  reason: ${routingPlan.decision.reason}`,
+          `  matched signals: ${routingPlan.decision.winningSignals.join(", ") || "none"}`
+        ]
+      : []),
+    ...(routingPlan.signals && routingPlan.signals.length > 0
+      ? [
+          "Signals:",
+          ...routingPlan.signals.map(
+            (signal) =>
+              `  - ${signal.name}: ${signal.matched ? "matched" : "not matched"}${
+                signal.evidence.length > 0 ? ` (${signal.evidence.join(", ")})` : ""
+              }`
+          ),
+          ""
+        ]
+      : []),
     "Planned stages:",
     ...routingPlan.stages.map((stage) => `  - ${stage.name}: ${stage.status} (${stage.rationale})`),
     "",
@@ -1739,7 +1758,7 @@ export async function executeInspectorCommand(cwd: string, inspection: RunInspec
     return { output: inspection.finalBody || "(missing)" };
   }
   if (trimmed === "r" || trimmed === "show routing") {
-    return { output: inspection.routingPlan ? `${JSON.stringify(inspection.routingPlan, null, 2)}\n` : "No routing plan recorded for this run." };
+    return { output: inspection.routingPlan ? renderRoutingSection(inspection).join("\n").trim() : "No routing plan recorded for this run." };
   }
   if (trimmed === "show research") {
     if (!inspection.discoverResearchPlan) {

--- a/src/intent.ts
+++ b/src/intent.ts
@@ -9,7 +9,9 @@ import { buildSpecPrompt, buildSpecialistPrompt, excerpt } from "./prompt.js";
 import { detectCodexVersion, detectGitBranch, ensureRunDir, makeRunId, readRun, writeRunRecord } from "./run.js";
 import type {
   CstackConfig,
+  RoutingDecision,
   RoutingPlan,
+  RoutingSignal,
   RunRecord,
   SpecialistDisposition,
   SpecialistExecution,
@@ -85,6 +87,66 @@ function isBroadAnalysisPrompt(lower: string): boolean {
     !hasImplementationIntent(lower) &&
     !hasReleaseIntent(lower)
   );
+}
+
+function collectRoutingSignals(intent: string): RoutingSignal[] {
+  const lower = intent.toLowerCase();
+  const analysisEvidence = [...intent.matchAll(
+    /\b(what are the gaps|gaps in (?:this|the current) project|what is missing|what's missing|assess(?: the)? current state|evaluate(?: the)? current state|key risks)\b/gi
+  )].map((match) => match[0]);
+  const implementationEvidence = [...intent.matchAll(
+    /\b(add|build|implement|fix|refactor|migrate|introduce|create|change|update|close|closing|resolve|address|remediate|work on)\b/gi
+  )].map((match) => match[0]);
+  const reviewEvidence = [...intent.matchAll(
+    /\b(review|audit|security|compliance|traceability|verify|check|gap|gaps|missing|assess|assessment|evaluate|evaluation)\b/gi
+  )].map((match) => match[0]);
+  const releaseEvidence = [...intent.matchAll(/\b(release|ship|deploy|rollout|pipeline|version)\b/gi)].map((match) => match[0]);
+
+  return [
+    { name: "analysis", matched: analysisEvidence.length > 0, evidence: analysisEvidence },
+    { name: "implementation", matched: implementationEvidence.length > 0, evidence: implementationEvidence },
+    { name: "review", matched: reviewEvidence.length > 0, evidence: reviewEvidence },
+    { name: "release", matched: releaseEvidence.length > 0, evidence: releaseEvidence }
+  ];
+}
+
+function inferRoutingDecision(stages: RoutingStagePlan[], signals: RoutingSignal[]): RoutingDecision {
+  const implementationSignal = signals.find((signal) => signal.name === "implementation");
+  const analysisSignal = signals.find((signal) => signal.name === "analysis");
+  const releaseSignal = signals.find((signal) => signal.name === "release");
+  const winningSignals = signals.filter((signal) => signal.matched).map((signal) => signal.name);
+
+  if (stages.length === 1 && stages[0]?.name === "review") {
+    return {
+      classification: "analysis",
+      reason: "Broad gap-analysis language matched without remediation or release intent, so the router skipped planning overhead and went straight to analytical review.",
+      winningSignals
+    };
+  }
+
+  if (implementationSignal?.matched && analysisSignal?.matched) {
+    return {
+      classification: "mixed",
+      reason:
+        "The prompt mixes gap-analysis language with explicit remediation intent, so the router stayed on the implementation path and carried the run through planning and downstream delivery stages.",
+      winningSignals
+    };
+  }
+
+  if (implementationSignal?.matched || releaseSignal?.matched) {
+    return {
+      classification: "implementation",
+      reason:
+        "Implementation or release language outweighed pure analysis intent, so the router kept deterministic planning and downstream delivery stages in the plan.",
+      winningSignals
+    };
+  }
+
+  return {
+    classification: "mixed",
+    reason: "The router kept the deterministic planning path because the prompt was broader than a pure gap-analysis request.",
+    winningSignals
+  };
 }
 
 function inferStagePlans(intent: string): RoutingStagePlan[] {
@@ -229,6 +291,8 @@ export function inferSpecialists(intent: string): SpecialistSelection[] {
 export function inferRoutingPlan(intent: string, entrypoint: "bare" | "run"): RoutingPlan {
   const stages = inferStagePlans(intent);
   const specialists = inferSpecialists(intent);
+  const signals = collectRoutingSignals(intent);
+  const decision = inferRoutingDecision(stages, signals);
   const selectedSpecialists = specialists.filter((specialist) => specialist.selected).map((specialist) => specialist.name);
   const summary =
     selectedSpecialists.length > 0
@@ -241,7 +305,9 @@ export function inferRoutingPlan(intent: string, entrypoint: "bare" | "run"): Ro
     entrypoint,
     stages,
     specialists,
-    summary
+    summary,
+    decision,
+    signals
   };
 }
 
@@ -290,6 +356,7 @@ function buildIntentContext(routingPlan: RoutingPlan): string {
   return [
     `Entry point: ${routingPlan.entrypoint}`,
     `Stages: ${routingPlan.stages.map((stage) => stage.name).join(", ")}`,
+    `Decision: ${routingPlan.decision?.classification ?? "unknown"} (${routingPlan.decision?.winningSignals.join(", ") || "no matched signals"})`,
     `Selected specialists: ${
       routingPlan.specialists.filter((specialist) => specialist.selected).map((specialist) => specialist.name).join(", ") || "none"
     }`

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,18 @@ export interface SpecialistSelection {
   selected: boolean;
 }
 
+export interface RoutingSignal {
+  name: "analysis" | "implementation" | "review" | "release";
+  matched: boolean;
+  evidence: string[];
+}
+
+export interface RoutingDecision {
+  classification: "analysis" | "implementation" | "mixed";
+  reason: string;
+  winningSignals: string[];
+}
+
 export interface SpecialistExecution {
   name: SpecialistName;
   reason: string;
@@ -112,6 +124,8 @@ export interface RoutingPlan {
   stages: RoutingStagePlan[];
   specialists: SpecialistSelection[];
   summary: string;
+  decision?: RoutingDecision;
+  signals?: RoutingSignal[];
 }
 
 export interface StageLineage {

--- a/test/inspect.test.ts
+++ b/test/inspect.test.ts
@@ -420,6 +420,18 @@ async function seedIntentFailedDeliverBuildRun(repoDir: string): Promise<string>
     inferredAt: "2026-03-16T12:49:00.000Z",
     entrypoint: "bare",
     summary: "Infer discover -> spec -> build -> review -> ship with no specialist reviews selected",
+    decision: {
+      classification: "mixed",
+      reason:
+        "The prompt mixes gap-analysis language with explicit remediation intent, so the router stayed on the implementation path and carried the run through planning and downstream delivery stages.",
+      winningSignals: ["analysis", "implementation", "review"]
+    },
+    signals: [
+      { name: "analysis", matched: true, evidence: ["What are the gaps"] },
+      { name: "implementation", matched: true, evidence: ["work on", "closing"] },
+      { name: "review", matched: true, evidence: ["gaps"] },
+      { name: "release", matched: false, evidence: [] }
+    ],
     stages: [
       { name: "discover", rationale: "Gather repo context.", status: "planned", executed: false },
       { name: "spec", rationale: "Plan the implementation.", status: "planned", executed: false },
@@ -1470,6 +1482,19 @@ describe("inspect", () => {
     await expect(handleInspectorCommand(repoDir, inspection, "show child build")).resolves.toContain("build final:");
     await expect(handleInspectorCommand(repoDir, inspection, "show child build")).resolves.toContain("Interactive codex exited with code 1");
     await expect(handleInspectorCommand(repoDir, inspection, "what remains")).resolves.toContain("child summary: interactive Codex exited with code 1");
+  });
+
+  it("explains routing decisions for mixed prompts in inspect output", async () => {
+    const failedIntentRunId = await seedIntentFailedDeliverBuildRun(repoDir);
+    const inspection = await loadRunInspection(repoDir, failedIntentRunId);
+
+    await expect(handleInspectorCommand(repoDir, inspection, "show routing")).resolves.toContain("Decision: mixed");
+    await expect(handleInspectorCommand(repoDir, inspection, "show routing")).resolves.toContain(
+      "matched signals: analysis, implementation, review"
+    );
+    await expect(handleInspectorCommand(repoDir, inspection, "show routing")).resolves.toContain(
+      "implementation: matched (work on, closing)"
+    );
   });
 
   it("surfaces direct build root cause inside failed deliver inspections", async () => {

--- a/test/intent.test.ts
+++ b/test/intent.test.ts
@@ -90,11 +90,20 @@ describe("intent router", () => {
   it("routes broad gap-analysis prompts directly into review", () => {
     const plan = inferRoutingPlan("What are the gaps in the current project?", "bare");
     expect(plan.stages.map((stage) => stage.name)).toEqual(["review"]);
+    expect(plan.decision?.classification).toBe("analysis");
+    expect(plan.decision?.winningSignals).toEqual(expect.arrayContaining(["analysis", "review"]));
+    expect(plan.signals?.find((signal) => signal.name === "analysis")?.matched).toBe(true);
+    expect(plan.signals?.find((signal) => signal.name === "implementation")?.matched).toBe(false);
   });
 
   it("routes gap-analysis prompts with explicit remediation intent into delivery stages", () => {
     const plan = inferRoutingPlan("What are the gaps in this project? Can you work on closing the gaps?", "bare");
     expect(plan.stages.map((stage) => stage.name)).toEqual(["discover", "spec", "build", "review", "ship"]);
+    expect(plan.decision?.classification).toBe("mixed");
+    expect(plan.decision?.winningSignals).toEqual(expect.arrayContaining(["analysis", "implementation", "review"]));
+    expect(plan.signals?.find((signal) => signal.name === "implementation")?.evidence).toEqual(
+      expect.arrayContaining(["work on", "closing"])
+    );
   });
 
   it("creates an intent run and auto-executes downstream delivery when the inferred plan warrants it", async () => {


### PR DESCRIPTION
## Summary
- persist explicit routing decision metadata and matched prompt signals in `routing-plan.json`
- make `show routing` render a readable decision summary instead of raw JSON
- add routing regressions for broad analysis and mixed remediation prompts

## Testing
- npm test -- test/intent.test.ts test/inspect.test.ts
- npm run typecheck
- npm test
- npm run build
- sqlite dry-run routing validation in /tmp/sqlite-metadata-proposal
