### PR TITLE
feat: harden github default-branch and check-watch failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ Deliver notes:
 - failed or timed-out build stages now become the root cause shown in both deliver summaries and parent intent inspection
 - when repo policy enables it, `deliver` can create or reuse a working branch, auto-commit the deliver change set, push it to `origin`, and create or update the GitHub pull request
 - `deliver` now evaluates GitHub-scoped engineering completion, including PR, checks, Actions, issue linkage, release evidence, and security gates when policy requires them
+- GitHub delivery failures stay root-cause-first: default-branch discovery failures and required-check watch failures are reported with their specific GitHub failure class, and the raw `gh` detail remains in the recorded blocker evidence
 - `deliver` fails closed when required GitHub evidence is missing or blocked
 - `deliver --release` switches the run into release-bearing mode and expects tag and release evidence
 - `deliver --issue <n>` links a specific GitHub issue into deliver evaluation

--- a/docs/specs/cstack-spec-v0.1.md
+++ b/docs/specs/cstack-spec-v0.1.md
@@ -302,6 +302,8 @@ When repo policy enables GitHub mutation, the wrapper may:
 - create or update the pull request
 - watch required checks
 
+GitHub mutation and delivery summaries must stay root-cause-first. When the wrapper cannot resolve the repository default branch or cannot complete required-check watching, the recorded summary must preserve that exact GitHub failure class and retain the raw `gh` detail as blocker evidence rather than collapsing it into a generic delivery failure.
+
 The wrapper does not currently promise to:
 
 - merge pull requests automatically

--- a/docs/workflows/current-project-workflow.md
+++ b/docs/workflows/current-project-workflow.md
@@ -143,7 +143,8 @@ Continuation commands:
 
 - treat `.cstack/runs/<run-id>/` as the durable source of truth
 - update inspector behavior whenever you introduce a new artifact family
-- `build`, `ship`, and `deliver` require a clean worktree unless `--allow-dirty` or repo policy allows otherwise
+- `build` and `deliver` execute from isolated checkouts by default and ignore uncommitted local dirt unless `--allow-dirty` or repo policy opts into source-repo dirty execution
+- `ship` still requires a clean worktree unless `--allow-dirty` or repo policy allows otherwise
 - GitHub mutation and GitHub delivery evidence must remain reconstructable from artifacts alone
 
 ## CI And Validation

--- a/src/github.ts
+++ b/src/github.ts
@@ -221,17 +221,28 @@ async function detectHeadSha(cwd: string): Promise<string> {
   }
 }
 
-async function detectDefaultBranch(ghCommand: string, cwd: string, repository: string | null): Promise<string | null> {
-  if (!repository) {
-    return null;
+async function resolveDefaultBranch(options: {
+  ghCommand: string;
+  cwd: string;
+  repository: string | null;
+}): Promise<{ name: string | null; failure?: { summary: string; detail: string } }> {
+  if (!options.repository) {
+    return {
+      name: null
+    };
   }
 
   try {
-    const { stdout } = await runGh(ghCommand, cwd, ["api", `repos/${repository}`]);
+    const { stdout } = await runGh(options.ghCommand, options.cwd, ["api", `repos/${options.repository}`]);
     const payload = JSON.parse(stdout) as { default_branch?: string };
-    return payload.default_branch ?? null;
-  } catch {
-    return null;
+    return {
+      name: payload.default_branch ?? null
+    };
+  } catch (error) {
+    return {
+      name: null,
+      failure: classifyGitHubFailure("resolving the repository default branch", error)
+    };
   }
 }
 
@@ -443,10 +454,11 @@ async function waitForRequiredChecks(options: {
   pullRequestNumber: number;
   timeoutSeconds: number;
   pollSeconds: number;
-}): Promise<{ polls: number; completed: boolean; summary: string }> {
+}): Promise<{ polls: number; completed: boolean; summary: string; blockers: string[] }> {
   const startedAt = Date.now();
   let polls = 0;
   let summary = "Required checks were not observed.";
+  const blockers: string[] = [];
 
   while ((Date.now() - startedAt) / 1000 < options.timeoutSeconds) {
     polls += 1;
@@ -476,21 +488,32 @@ async function waitForRequiredChecks(options: {
           return {
             polls,
             completed: true,
-            summary
+            summary,
+            blockers
           };
         }
       }
     } catch (error) {
-      summary = error instanceof Error ? error.message : String(error);
+      const failure = classifyGitHubFailure("watching required checks", error);
+      blockers.push(failure.summary);
+      blockers.push(failure.detail);
+      return {
+        polls,
+        completed: false,
+        summary: failure.summary,
+        blockers
+      };
     }
 
     await new Promise((resolve) => setTimeout(resolve, options.pollSeconds * 1000));
   }
 
+  blockers.push(`Timed out while waiting for required checks. Last observation: ${summary}`);
   return {
     polls,
     completed: false,
-    summary: `Timed out while waiting for required checks. Last observation: ${summary}`
+    summary: `Timed out while waiting for required checks. Last observation: ${summary}`,
+    blockers
   };
 }
 
@@ -1025,7 +1048,8 @@ export async function performGitHubDeliverMutations(options: PerformGitHubMutati
   const remote = await resolveRemoteForPush(options.cwd);
   const { repository } = await detectRepository(options.cwd, policy.repository);
   const ghCommand = policy.command || "gh";
-  const defaultBranch = await detectDefaultBranch(ghCommand, options.cwd, repository);
+  const defaultBranchInfo = await resolveDefaultBranch({ ghCommand, cwd: options.cwd, repository });
+  const defaultBranch = defaultBranchInfo.name;
   let branch = options.gitBranch;
   let createdBranch = false;
   let pushed = false;
@@ -1036,6 +1060,11 @@ export async function performGitHubDeliverMutations(options: PerformGitHubMutati
   let pullRequestUpdated = false;
   let pullRequestRecord: GitHubPullRequestRecord | null = null;
   const blockers: string[] = [];
+
+  if (!policy.pullRequestBase && repository && !defaultBranch && defaultBranchInfo.failure) {
+    blockers.push(defaultBranchInfo.failure.summary);
+    blockers.push(defaultBranchInfo.failure.detail);
+  }
 
   if (!enabled) {
     return {
@@ -1215,6 +1244,9 @@ export async function performGitHubDeliverMutations(options: PerformGitHubMutati
     checkPolls = watchResult.polls;
     checksCompleted = watchResult.completed;
     checksSummary = watchResult.summary;
+    if (watchResult.blockers.length > 0) {
+      blockers.push(...watchResult.blockers);
+    }
   }
 
   return {
@@ -1373,21 +1405,38 @@ export async function collectGitHubDeliveryEvidence(options: CollectGitHubDelive
   const ghCommand = policy.command || "gh";
   const { repository, remoteUrl } = await detectRepository(options.cwd, policy.repository);
   const headSha = await detectHeadSha(options.cwd);
-  const defaultBranch = await detectDefaultBranch(ghCommand, options.cwd, repository);
+  const defaultBranchInfo = await resolveDefaultBranch({ ghCommand, cwd: options.cwd, repository });
+  const defaultBranch = defaultBranchInfo.name;
+  const requiresDefaultBranch =
+    !policy.pullRequestBase &&
+    Boolean(
+      policy.pushBranch ||
+        policy.createPullRequest ||
+        policy.updatePullRequest ||
+        policy.prRequired ||
+        options.deliveryMode === "merge-ready"
+    );
+  const branchBlockers =
+    repository && options.gitBranch && headSha
+      ? requiresDefaultBranch && !defaultBranch && defaultBranchInfo.failure
+        ? [defaultBranchInfo.failure.summary, defaultBranchInfo.failure.detail]
+        : []
+      : ["GitHub repository, branch, or HEAD SHA could not be resolved."];
 
   const branchState = gate(
     true,
-    repository && options.gitBranch && headSha ? "ready" : "blocked",
-    repository && options.gitBranch && headSha
+    branchBlockers.length === 0 ? "ready" : "blocked",
+    branchBlockers.length === 0
       ? `Resolved ${repository} on branch ${options.gitBranch}.`
-      : "GitHub repository, branch, or HEAD SHA could not be resolved.",
+      : branchBlockers[0]!,
     {
       current: options.gitBranch,
       headSha,
       defaultBranch
     },
     repository ? "git" : "none",
-    repository && options.gitBranch && headSha ? [] : ["GitHub repository, branch, or HEAD SHA could not be resolved."]
+    branchBlockers,
+    branchBlockers.length > 1 ? branchBlockers[1] : undefined
   );
 
   const pullRequest = await detectPullRequest({
@@ -1515,6 +1564,7 @@ export async function collectGitHubDeliveryEvidence(options: CollectGitHubDelive
     },
     limitations: [
       remoteUrl ? `origin remote: ${remoteUrl}` : "origin remote could not be resolved",
+      ...(defaultBranchInfo.failure ? [`default branch lookup: ${defaultBranchInfo.failure.summary}`] : []),
       "GitHub evidence is based on current observable git and gh state; unavailable permissions are reported as blockers when the policy requires those checks."
     ]
   };

--- a/test/deliver.test.ts
+++ b/test/deliver.test.ts
@@ -6,6 +6,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { chmodSync } from "node:fs";
 import { runDeliver } from "../src/commands/deliver.js";
+import { performGitHubDeliverMutations } from "../src/github.js";
 import { listRuns, readRun } from "../src/run.js";
 import type { RunRecord, StageLineage } from "../src/types.js";
 
@@ -756,5 +757,117 @@ describe("runDeliver", () => {
     expect(run.status).toBe("failed");
     expect(githubMutation.summary).toContain("GitHub failed while creating or updating the pull request.");
     expect(githubMutation.blockers.join("\n")).toContain("modified concurrently");
+  });
+
+  it("fails closed when the default branch cannot be resolved for PR mutation", async () => {
+    await writeGitHubFixture({
+      repoApiError: "HTTP 403: resource not accessible while resolving default branch",
+      issues: [
+        {
+          number: 906,
+          title: "Default branch discovery issue",
+          state: "CLOSED",
+          url: "https://github.com/ganesh47/cstack/issues/906",
+          closedAt: "2026-03-14T00:00:00.000Z"
+        }
+      ],
+      prChecks: [],
+      actions: [],
+      security: {
+        dependabot: [],
+        codeScanning: []
+      }
+    });
+
+    await fs.writeFile(path.join(repoDir, "delivery-change.txt"), "deliver change\n", "utf8");
+
+    const result = await performGitHubDeliverMutations({
+      cwd: repoDir,
+      gitBranch: "main",
+      runId: "test-default-branch",
+      input: "Deliver a fix that will hit default branch discovery failure for #906",
+      issueNumbers: [906],
+      policy: {
+        enabled: true,
+        command: path.resolve("test/fixtures/fake-gh.mjs"),
+        repository: "ganesh47/cstack",
+        pushBranch: true,
+        branchPrefix: "cstack",
+        commitChanges: true,
+        createPullRequest: true,
+        updatePullRequest: true,
+        watchChecks: true,
+        checkWatchTimeoutSeconds: 1,
+        checkWatchPollSeconds: 0
+      },
+      buildSummary: "Build completed.",
+      reviewVerdict: {
+        mode: "readiness",
+        status: "ready",
+        summary: "Ready",
+        findings: [],
+        recommendedActions: [],
+        acceptedSpecialists: [],
+        reportMarkdown: "# Review\n"
+      },
+      verificationRecord: {},
+      pullRequestBodyPath: path.join(repoDir, ".cstack", "pr-body.md")
+    });
+
+    expect(result.record.summary).toContain("GitHub authentication failed while resolving the repository default branch.");
+    expect(result.record.blockers.join("\n")).toContain("resource not accessible");
+    expect(result.record.branch.created).toBe(true);
+    expect(result.record.pullRequest.created).toBe(false);
+  });
+
+  it("surfaces required-check watch timeouts as GitHub mutation blockers", async () => {
+    await writeGitHubFixture({
+      repoView: {
+        nameWithOwner: "ganesh47/cstack",
+        defaultBranchRef: { name: "main" }
+      },
+      createdPullRequest: {
+        reviewDecision: "APPROVED",
+        mergeStateStatus: "CLEAN"
+      },
+      issues: [
+        {
+          number: 907,
+          title: "Checks timeout issue",
+          state: "CLOSED",
+          url: "https://github.com/ganesh47/cstack/issues/907",
+          closedAt: "2026-03-14T00:00:00.000Z"
+        }
+      ],
+      prChecks: [
+        { name: "deliver/test", bucket: "pending", state: "queued", workflow: "CI", link: "https://github.com/ganesh47/cstack/actions/runs/10" },
+        { name: "deliver/typecheck", bucket: "pending", state: "in_progress", workflow: "CI", link: "https://github.com/ganesh47/cstack/actions/runs/11" }
+      ],
+      actions: [
+        { databaseId: 1, workflowName: "Release", status: "completed", conclusion: "success", url: "https://github.com/ganesh47/cstack/actions/runs/1" }
+      ],
+      security: {
+        dependabot: [],
+        codeScanning: []
+      }
+    });
+
+    await runDeliver(repoDir, ["Deliver a fix that will hit required-check watch timeout for #907"]);
+
+    const runs = await listRuns(repoDir);
+    const run = await readRun(repoDir, runs[0]!.id);
+    const runDir = path.dirname(run.finalPath);
+    const githubMutation = JSON.parse(await fs.readFile(path.join(runDir, "artifacts", "github-mutation.json"), "utf8")) as {
+      summary: string;
+      blockers: string[];
+      checks: { watched: boolean; completed: boolean; summary: string };
+    };
+
+    expect(run.status).toBe("failed");
+    expect(githubMutation.checks.watched).toBe(true);
+    expect(githubMutation.checks.completed).toBe(false);
+    expect(githubMutation.checks.summary).toContain("Timed out while waiting for required checks.");
+    expect(githubMutation.summary).toContain("Timed out while waiting for required checks.");
+    expect(githubMutation.blockers.join("\n")).toContain("Waiting for 2 required checks.");
   });
 });


### PR DESCRIPTION
## Summary
- fail closed with root-cause-first summaries when GitHub default-branch discovery is required but cannot be resolved
- preserve blocker evidence when required-check watching fails or times out
- align the workflow guide and README/spec notes with the shipped isolated-execution and GitHub failure contract

## Testing
- npm test -- test/deliver.test.ts
- npm run typecheck
- npm test
- npm run build
