### PR TITLE
feat: make validation profiling workspace-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,7 +590,8 @@ Ship notes:
 Deliver notes:
 
 - `deliver` is the operator-facing umbrella workflow over internal `build`, `validation`, `review`, and `ship` stages
-- the validation stage profiles the repo, chooses a layered validation strategy, records OSS tool research, and runs the selected local validation commands
+- the validation stage profiles the repo, inventories nested workspace targets, chooses a layered validation strategy, records OSS tool research, and runs the selected local validation commands
+- validation command inference is still root-biased by default; nested packages, Python targets, and container folders are surfaced explicitly in the profile and gaps when they are not backed by deterministic repo-level commands
 - stage-local artifacts live under `stages/build`, `stages/validation`, `stages/review`, and `stages/ship`
 - `deliver` executes those mutation-capable stages from an isolated checkout by default and records the source-vs-execution lineage in `execution-context.json`
 - if the internal `build` stage fails, `deliver` now stops immediately and marks `validation`, `review`, and `ship` as blocked/deferred instead of continuing to run them
@@ -603,6 +604,7 @@ Deliver notes:
 - `deliver --issue <n>` links a specific GitHub issue into deliver evaluation
 - uncommitted local source edits are ignored by default for `deliver`; `--allow-dirty` remains the explicit opt-in for source-repo dirty execution
 - `cstack inspect <run-id>` supports `show validation`, `show pyramid`, `show coverage`, `show ci-validation`, `show tool-research`, `show review`, `show ship`, `show mutation`, and `show github` for deliver runs
+- `show validation` now summarizes workspace targets and support levels before the raw plan so mixed repos are easier to reason about
 - when a deliver build fails, `cstack inspect` now separates the root-cause build failure from later blocked stages and surfaces timeout/session/transcript evidence when available
 
 ## Development

--- a/docs/specs/cstack-spec-v0.1.md
+++ b/docs/specs/cstack-spec-v0.1.md
@@ -222,6 +222,7 @@ Execution model:
 
 - build stage: interactive `codex` by default, `exec` fallback or `--exec`
 - validation stage: repo-aware validation planning plus bounded validation specialists and local command execution
+  the shipped profile inventories nested workspace targets, but local command inference is still strongest at the repo root unless the repo already exposes deterministic package-level entrypoints
 - review stage: `codex exec` plus bounded specialist reviewers
 - ship stage: `codex exec` plus GitHub mutation and delivery evidence collection
 

--- a/docs/workflows/current-project-workflow.md
+++ b/docs/workflows/current-project-workflow.md
@@ -38,7 +38,7 @@ Implemented behavior:
 - `review` is a standalone critique workflow with verdict artifacts and bounded specialist reviewers
 - `ship` is a standalone GitHub-aware handoff and release-readiness workflow
 - `deliver` runs internal `build -> validation -> review -> ship` inside one durable run
-- `deliver` validation profiles the repo, records OSS tool research, writes a test pyramid, and runs selected local validation commands
+- `deliver` validation profiles the repo, inventories nested workspace targets, records OSS tool research, writes a test pyramid, and runs selected local validation commands
 - `deliver` and `ship` can publish branches and create or update pull requests when repo policy enables it
 - `rerun` replays supported workflows into fresh run ids
 - `resume` and `fork` resolve run ids to Codex sessions

--- a/src/deliver.ts
+++ b/src/deliver.ts
@@ -257,6 +257,7 @@ function createBlockedValidationExecution(buildExecution: BuildExecutionResult):
       existingTests: [],
       packageScripts: [],
       detectedTools: [],
+      workspaceTargets: [],
       limitations: ["Validation profiling was skipped because build failed first."]
     },
     toolResearch: {

--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -1153,7 +1153,24 @@ function renderValidation(inspection: RunInspection): string {
     return "No validation plan was recorded for this run.";
   }
 
+  const summaryLines =
+    inspection.validationRepoProfile
+      ? [
+          `Validation status: ${inspection.validationPlan.status}`,
+          `Profile surfaces: ${inspection.validationRepoProfile.surfaces.join(", ") || "unknown"}`,
+          `Workspace targets: ${inspection.validationRepoProfile.workspaceTargets.length}`,
+          ...inspection.validationRepoProfile.workspaceTargets.map(
+            (target) =>
+              `- ${target.path}: ${target.support} (${target.surfaces.join(", ") || "unknown surface"}; manifests ${target.manifests.join(", ") || "none"})`
+          ),
+          ...(inspection.validationRepoProfile.limitations.length > 0
+            ? ["Limitations:", ...inspection.validationRepoProfile.limitations.map((line) => `- ${line}`)]
+            : [])
+        ]
+      : [];
+
   return [
+    ...(summaryLines.length > 0 ? [...summaryLines, ""] : []),
     JSON.stringify(inspection.validationPlan, null, 2),
     "",
     inspection.validationLocalRecord ? JSON.stringify(inspection.validationLocalRecord, null, 2) : "No local validation record was recorded for this run."

--- a/src/types.ts
+++ b/src/types.ts
@@ -451,6 +451,18 @@ export interface ValidationExistingTestSuite {
   tool?: string;
 }
 
+export interface ValidationWorkspaceTarget {
+  path: string;
+  manifests: string[];
+  languages: string[];
+  buildSystems: string[];
+  surfaces: string[];
+  packageScripts: ValidationDetectedScript[];
+  detectedTools: string[];
+  support: "native" | "partial" | "inventory-only";
+  notes: string[];
+}
+
 export interface ValidationRepoProfile {
   detectedAt: string;
   languages: string[];
@@ -464,6 +476,7 @@ export interface ValidationRepoProfile {
   existingTests: ValidationExistingTestSuite[];
   packageScripts: ValidationDetectedScript[];
   detectedTools: string[];
+  workspaceTargets: ValidationWorkspaceTarget[];
   limitations: string[];
 }
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -17,9 +17,11 @@ import type {
   SpecialistName,
   ValidationCommandRecord,
   ValidationCoverageSummary,
+  ValidationDetectedScript,
   ValidationRepoProfile,
   ValidationToolCandidate,
-  ValidationToolResearch
+  ValidationToolResearch,
+  ValidationWorkspaceTarget
 } from "./types.js";
 
 const execFileAsync = promisify(execFile);
@@ -178,6 +180,14 @@ async function collectManifestHints(cwd: string): Promise<string[]> {
   return manifests;
 }
 
+async function readPackageJsonAt(filePath: string): Promise<Record<string, unknown> | null> {
+  try {
+    return JSON.parse(await fs.readFile(filePath, "utf8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
 async function findFiles(cwd: string, names: string[], options: { maxDepth?: number; maxResults?: number } = {}): Promise<string[]> {
   const maxDepth = options.maxDepth ?? 4;
   const maxResults = options.maxResults ?? 50;
@@ -223,6 +233,24 @@ function pushUnique(target: string[], values: string[]): void {
       target.push(value);
     }
   }
+}
+
+function classifyWorkspaceSupport(target: {
+  path: string;
+  manifests: string[];
+  packageScripts: ValidationDetectedScript[];
+  workflowFiles: string[];
+}): ValidationWorkspaceTarget["support"] {
+  if (target.path === ".") {
+    return "native";
+  }
+  if (target.workflowFiles.length > 0) {
+    return "native";
+  }
+  if (target.manifests.includes("package.json") && target.packageScripts.length > 0) {
+    return "partial";
+  }
+  return "inventory-only";
 }
 
 function extractPackageScripts(pkg: Record<string, unknown> | null): Array<{ name: string; command: string }> {
@@ -414,6 +442,109 @@ function buildExistingSuites(options: {
   return suites;
 }
 
+async function collectWorkspaceTargets(cwd: string, rootPkg: Record<string, unknown> | null, rootManifests: string[], workflowFiles: string[]): Promise<ValidationWorkspaceTarget[]> {
+  const manifestFiles = await findFiles(
+    cwd,
+    [
+      "package.json",
+      "pyproject.toml",
+      "requirements.txt",
+      "Cargo.toml",
+      "go.mod",
+      "Dockerfile",
+      "docker-compose.yml",
+      "docker-compose.yaml",
+      "build.gradle",
+      "build.gradle.kts",
+      "settings.gradle",
+      "settings.gradle.kts",
+      "Package.swift",
+      "Podfile"
+    ],
+    { maxDepth: 6, maxResults: 200 }
+  );
+  const targets = new Map<string, ValidationWorkspaceTarget>();
+  const ensureTarget = async (targetPath: string): Promise<ValidationWorkspaceTarget> => {
+    const existing = targets.get(targetPath);
+    if (existing) {
+      return existing;
+    }
+    const pkgPath = targetPath === "." ? path.join(cwd, "package.json") : path.join(cwd, targetPath, "package.json");
+    const pkg = targetPath === "." ? rootPkg : await readPackageJsonAt(pkgPath);
+    const manifests = targetPath === "." ? [...rootManifests] : [];
+    const workflowSubset = targetPath === "." ? [...workflowFiles] : [];
+    const target: ValidationWorkspaceTarget = {
+      path: targetPath,
+      manifests,
+      languages: detectLanguages(manifests, pkg),
+      buildSystems: detectBuildSystems(manifests, pkg),
+      surfaces: [],
+      packageScripts: extractPackageScripts(pkg),
+      detectedTools: collectPackageTools(pkg),
+      support: "inventory-only",
+      notes: []
+    };
+    targets.set(targetPath, target);
+    return target;
+  };
+
+  const rootTarget = await ensureTarget(".");
+  rootTarget.surfaces = detectSurfaces({
+    pkg: rootPkg,
+    manifests: rootTarget.manifests,
+    detectedTools: rootTarget.detectedTools,
+    workflowFiles,
+    existingTests: []
+  });
+  rootTarget.support = classifyWorkspaceSupport({
+    path: ".",
+    manifests: rootTarget.manifests,
+    packageScripts: rootTarget.packageScripts,
+    workflowFiles
+  });
+
+  for (const manifestFile of manifestFiles) {
+    const directory = path.dirname(manifestFile);
+    const targetPath = directory === "" ? "." : directory;
+    const target = await ensureTarget(targetPath);
+    const manifestName = path.basename(manifestFile);
+    if (!target.manifests.includes(manifestName)) {
+      target.manifests.push(manifestName);
+      target.manifests.sort();
+    }
+  }
+
+  for (const target of targets.values()) {
+    const pkgPath = target.path === "." ? path.join(cwd, "package.json") : path.join(cwd, target.path, "package.json");
+    const pkg = target.path === "." ? rootPkg : await readPackageJsonAt(pkgPath);
+    target.languages = detectLanguages(target.manifests, pkg);
+    target.buildSystems = detectBuildSystems(target.manifests, pkg);
+    target.packageScripts = extractPackageScripts(pkg);
+    target.detectedTools = collectPackageTools(pkg);
+    target.surfaces = detectSurfaces({
+      pkg,
+      manifests: target.manifests,
+      detectedTools: target.detectedTools,
+      workflowFiles: target.path === "." ? workflowFiles : [],
+      existingTests: []
+    });
+    target.support = classifyWorkspaceSupport({
+      path: target.path,
+      manifests: target.manifests,
+      packageScripts: target.packageScripts,
+      workflowFiles: target.path === "." ? workflowFiles : []
+    });
+    if (target.path !== "." && target.support !== "native") {
+      target.notes.push("Validation command inference is currently rooted in the top-level repo; inspect this target manually.");
+    }
+    if (target.path !== "." && !target.manifests.includes("package.json")) {
+      target.notes.push("No top-level JS package manifest was found for this target.");
+    }
+  }
+
+  return [...targets.values()].sort((left, right) => left.path.localeCompare(right.path));
+}
+
 export async function profileValidationRepository(cwd: string): Promise<ValidationRepoProfile> {
   const pkg = await readPackageJson(cwd);
   const manifests = await collectManifestHints(cwd);
@@ -450,6 +581,7 @@ export async function profileValidationRepository(cwd: string): Promise<Validati
     existingTests: existingTests.map((entry) => entry.location)
   });
   const ciSystems = workflowFiles.length > 0 ? ["github-actions"] : [];
+  const workspaceTargets = await collectWorkspaceTargets(cwd, pkg, manifests, workflowFiles);
   const runnerConstraints: string[] = [];
   if (surfaces.includes("ios-app")) {
     runnerConstraints.push("macos-required", "ios-simulator");
@@ -474,6 +606,13 @@ export async function profileValidationRepository(cwd: string): Promise<Validati
   if (surfaces.length === 0) {
     limitations.push("Repository surface could not be classified confidently.");
   }
+  const nestedTargets = workspaceTargets.filter((target) => target.path !== ".");
+  if (nestedTargets.length > 0) {
+    limitations.push("Validation command inference is currently root-biased; nested workspace targets are inventoried and reported explicitly.");
+  }
+  for (const target of nestedTargets.filter((entry) => entry.support !== "native")) {
+    limitations.push(`Workspace target ${target.path} is ${target.support}; direct validation commands were not inferred for it.`);
+  }
 
   return {
     detectedAt: new Date().toISOString(),
@@ -488,6 +627,7 @@ export async function profileValidationRepository(cwd: string): Promise<Validati
     existingTests,
     packageScripts: scripts,
     detectedTools: packageTools,
+    workspaceTargets,
     limitations
   };
 }
@@ -745,7 +885,7 @@ function buildInitialValidationPlan(profile: ValidationRepoProfile, toolResearch
   return {
     status: localCommands.length > 0 ? "ready" : "partial",
     summary: `Validation planning selected ${layers.filter((layer) => layer.selected).length} pyramid layers.`,
-    profileSummary: `Surfaces: ${profile.surfaces.join(", ") || "unknown"}; build systems: ${profile.buildSystems.join(", ") || "unknown"}.`,
+    profileSummary: `Surfaces: ${profile.surfaces.join(", ") || "unknown"}; build systems: ${profile.buildSystems.join(", ") || "unknown"}; workspace targets: ${profile.workspaceTargets.length}.`,
     layers,
     selectedSpecialists: selectedSpecialists.filter((entry) => entry.selected).map((entry) => ({
       name: entry.name,
@@ -763,9 +903,14 @@ function buildInitialValidationPlan(profile: ValidationRepoProfile, toolResearch
       notes: profile.workflowFiles.length > 0 ? [] : ["GitHub Actions workflow files are not present yet."]
     },
     coverage: {
-      confidence: localCommands.length > 0 ? "medium" : "low",
+      confidence: localCommands.length > 0 && profile.limitations.length === 0 ? "medium" : "low",
       summary: "Coverage is summarized by layer, with emphasis on representative risk reduction rather than one percentage.",
-      signals: ["repo profile completed", "tool families selected", "pyramid layers planned"],
+      signals: [
+        "repo profile completed",
+        "tool families selected",
+        "pyramid layers planned",
+        ...(profile.workspaceTargets.length > 1 ? [`workspace inventory recorded for ${profile.workspaceTargets.length} targets`] : [])
+      ],
       gaps: localCommands.length > 0 ? [] : ["No runnable local validation commands were inferred."]
     },
     recommendedChanges: [],

--- a/test/inspect.test.ts
+++ b/test/inspect.test.ts
@@ -901,7 +901,31 @@ async function seedDeliverRun(
         existingTests: [{ kind: "unit", location: "test/inspect.test.ts", tool: "vitest" }],
         packageScripts: [{ name: "test", command: "npm test" }],
         detectedTools: ["vitest"],
-        limitations: []
+        workspaceTargets: [
+          {
+            path: ".",
+            manifests: ["package.json"],
+            languages: ["typescript"],
+            buildSystems: ["npm"],
+            surfaces: ["cli-binary", "github-workflows"],
+            packageScripts: [{ name: "test", command: "npm test" }],
+            detectedTools: ["vitest"],
+            support: "native",
+            notes: []
+          },
+          {
+            path: "packages/cli",
+            manifests: ["pyproject.toml"],
+            languages: ["python"],
+            buildSystems: ["python"],
+            surfaces: ["library"],
+            packageScripts: [],
+            detectedTools: [],
+            support: "inventory-only",
+            notes: ["Validation command inference is currently rooted in the top-level repo; inspect this target manually."]
+          }
+        ],
+        limitations: ["Validation command inference is currently root-biased; nested workspace targets are inventoried and reported explicitly."]
       },
       null,
       2
@@ -1363,7 +1387,9 @@ describe("inspect", () => {
     expect(inspection.githubDeliveryRecord?.overall.status).toBe("blocked");
     expect(inspection.run.status).toBe("failed");
     await expect(handleInspectorCommand(repoDir, inspection, "show verification")).resolves.toContain("\"status\": \"passed\"");
+    await expect(handleInspectorCommand(repoDir, inspection, "show validation")).resolves.toContain("Workspace targets: 2");
     await expect(handleInspectorCommand(repoDir, inspection, "show validation")).resolves.toContain("\"status\": \"partial\"");
+    await expect(handleInspectorCommand(repoDir, inspection, "show validation")).resolves.toContain("packages/cli: inventory-only");
     await expect(handleInspectorCommand(repoDir, inspection, "show pyramid")).resolves.toContain("# Test Pyramid");
     await expect(handleInspectorCommand(repoDir, inspection, "show coverage")).resolves.toContain("\"localValidationStatus\": \"passed\"");
     await expect(handleInspectorCommand(repoDir, inspection, "show ci-validation")).resolves.toContain("\"runner\": \"ubuntu-latest\"");

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -59,6 +59,65 @@ describe("validation intelligence", () => {
     expect(profile.ciSystems).toContain("github-actions");
     expect(profile.runnerConstraints).toContain("docker-preferred");
     expect(profile.packageScripts.map((script) => script.name)).toEqual(["lint", "test", "test:e2e", "typecheck"]);
+    expect(profile.workspaceTargets.find((target) => target.path === ".")?.support).toBe("native");
+  });
+
+  it("profiles nested workspace targets truthfully", async () => {
+    await fs.mkdir(path.join(repoDir, "packages", "api"), { recursive: true });
+    await fs.mkdir(path.join(repoDir, "packages", "cli"), { recursive: true });
+    await fs.mkdir(path.join(repoDir, "docker", "api"), { recursive: true });
+
+    await fs.writeFile(
+      path.join(repoDir, "package.json"),
+      JSON.stringify(
+        {
+          name: "fixture-monorepo",
+          private: true,
+          scripts: {
+            test: "vitest run"
+          },
+          workspaces: ["packages/*"],
+          devDependencies: {
+            vitest: "^3.2.4"
+          }
+        },
+        null,
+        2
+      ),
+      "utf8"
+    );
+    await fs.writeFile(
+      path.join(repoDir, "packages", "api", "package.json"),
+      JSON.stringify(
+        {
+          name: "@fixture/api",
+          version: "1.0.0",
+          scripts: {
+            test: "vitest run"
+          },
+          dependencies: {
+            express: "^5.0.0"
+          },
+          devDependencies: {
+            vitest: "^3.2.4"
+          }
+        },
+        null,
+        2
+      ),
+      "utf8"
+    );
+    await fs.writeFile(path.join(repoDir, "packages", "cli", "pyproject.toml"), "[project]\nname='fixture-cli'\n", "utf8");
+    await fs.writeFile(path.join(repoDir, "docker", "api", "Dockerfile"), "FROM node:24-alpine\n", "utf8");
+
+    const profile = await profileValidationRepository(repoDir);
+
+    expect(profile.workspaceTargets.map((target) => target.path)).toEqual([".", "docker/api", "packages/api", "packages/cli"]);
+    expect(profile.workspaceTargets.find((target) => target.path === "packages/api")?.support).toBe("partial");
+    expect(profile.workspaceTargets.find((target) => target.path === "packages/cli")?.support).toBe("inventory-only");
+    expect(profile.workspaceTargets.find((target) => target.path === "docker/api")?.support).toBe("inventory-only");
+    expect(profile.limitations).toContain("Validation command inference is currently root-biased; nested workspace targets are inventoried and reported explicitly.");
+    expect(profile.limitations.join("\n")).toContain("packages/cli");
   });
 
   it("selects OSS tool research aligned with the repo profile", async () => {


### PR DESCRIPTION
## Summary
- inventory nested workspace targets in the validation repo profile and mark them as native, partial, or inventory-only
- surface workspace support levels in `cstack inspect show validation`
- narrow the spec, README, and workflow guide so validation truthfully describes its root-biased command inference on mixed repos

## Testing
- npm test -- test/validation.test.ts test/inspect.test.ts
- npm run typecheck
- npm test
- npm run build
- node --input-type=module -e "import { profileValidationRepository } from './dist/validation.js'; const profile = await profileValidationRepository('/tmp/sqlite-metadata-proposal'); console.log(JSON.stringify({ surfaces: profile.surfaces, workspaceTargets: profile.workspaceTargets.map((t) => ({ path: t.path, support: t.support })), limitations: profile.limitations }, null, 2));"
