### PR TITLE
fix: shell-quote inferred workspace validation paths

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -647,17 +647,22 @@ function buildPackageScriptCommand(packageManager: "npm" | "pnpm" | "yarn", scri
   return packageManager === "npm" ? `npm run ${scriptName}` : `${packageManager} ${scriptName}`;
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\"'\"'")}'`;
+}
+
 function buildWorkspacePackageScriptCommand(packageManager: "npm" | "pnpm" | "yarn", targetPath: string, scriptName: string): string {
   if (targetPath === ".") {
     return buildPackageScriptCommand(packageManager, scriptName);
   }
+  const quotedPath = shellQuote(targetPath);
   if (packageManager === "npm") {
-    return `npm --prefix ${targetPath} run ${scriptName}`;
+    return `npm --prefix ${quotedPath} run ${scriptName}`;
   }
   if (packageManager === "yarn") {
-    return `yarn --cwd ${targetPath} ${scriptName}`;
+    return `yarn --cwd ${quotedPath} ${scriptName}`;
   }
-  return `pnpm --dir ${targetPath} ${scriptName}`;
+  return `pnpm --dir ${quotedPath} ${scriptName}`;
 }
 
 function parsePyprojectRequiresPython(raw: string): string | null {
@@ -703,15 +708,15 @@ async function inferWorkspaceTargetDetails(options: {
       addPrerequisite(`uv available on PATH for ${options.targetPath}`);
     }
     if (/\[tool\.ruff\]/i.test(pyproject) || /\bruff\b/i.test(pyproject)) {
-      addCommand(`cd ${options.targetPath} && uv run ruff check .`);
+      addCommand(`cd ${shellQuote(options.targetPath)} && uv run ruff check .`);
     }
     if (/\[tool\.pytest\.ini_options\]/i.test(pyproject) || /\bpytest\b/i.test(pyproject)) {
-      addCommand(`cd ${options.targetPath} && uv run pytest`);
+      addCommand(`cd ${shellQuote(options.targetPath)} && uv run pytest`);
     }
   }
 
   if (options.manifests.includes("pom.xml")) {
-    addCommand(`mvn --batch-mode -f ${options.targetPath}/pom.xml verify`);
+    addCommand(`mvn --batch-mode -f ${shellQuote(`${options.targetPath}/pom.xml`)} verify`);
     addPrerequisite(`Java required for ${options.targetPath}`);
   }
 

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -320,12 +320,24 @@ describe("validation intelligence", () => {
     const commands = selectDefaultLocalCommands(profile, { status: "passed", requestedCommands: [], results: [] });
 
     expect(commands).toContain("pnpm check");
-    expect(commands).toContain("pnpm --dir packages/api lint");
-    expect(commands).toContain("pnpm --dir packages/api test");
-    expect(commands).toContain("cd packages/cli && uv run ruff check .");
-    expect(commands).toContain("cd packages/cli && uv run pytest");
+    expect(commands).toContain("pnpm --dir 'packages/api' lint");
+    expect(commands).toContain("pnpm --dir 'packages/api' test");
+    expect(commands).toContain("cd 'packages/cli' && uv run ruff check .");
+    expect(commands).toContain("cd 'packages/cli' && uv run pytest");
     expect(profile.prerequisites).toContain("Node 20.17.0 from .nvmrc");
     expect(profile.prerequisites).toContain("Python >=3.12 for packages/cli");
     expect(profile.prerequisites).toContain("uv available on PATH for packages/cli");
+  });
+
+  it("shell-quotes inferred nested workspace paths", async () => {
+    const nestedPath = path.join(repoDir, "packages", "evil;touch /tmp/cstack_pwned");
+    await fs.mkdir(nestedPath, { recursive: true });
+    await fs.writeFile(path.join(repoDir, "package.json"), JSON.stringify({ name: "fixture", private: true, packageManager: "pnpm@9.12.0" }), "utf8");
+    await fs.writeFile(path.join(nestedPath, "package.json"), JSON.stringify({ name: "@fixture/evil", private: true, scripts: { test: "vitest run" } }), "utf8");
+
+    const profile = await profileValidationRepository(repoDir);
+    const commands = selectDefaultLocalCommands(profile, { status: "passed", requestedCommands: [], results: [] });
+
+    expect(commands).toContain("pnpm --dir 'packages/evil;touch /tmp/cstack_pwned' test");
   });
 });


### PR DESCRIPTION
### Motivation
- Inferred validation commands embedded repository-controlled workspace paths directly into shell strings (e.g., `npm --prefix ${targetPath} ...`, `cd ${targetPath} && ...`, `mvn -f ${targetPath}/pom.xml ...`) which were later executed with a shell (`-lc`), creating a command-injection risk from malicious directory names.

### Description
- Add a `shellQuote` helper that POSIX single-quotes values and safely escapes embedded single quotes via `value.replace(/'/g, "'\"'\"'")`.
- Use `shellQuote` when interpolating nested workspace `targetPath` into inferred package manager commands in `buildWorkspacePackageScriptCommand` for `npm`, `yarn`, and `pnpm` so paths are quoted.
- Use `shellQuote` for `cd`-based `uv` commands and for the Maven `-f` argument in `inferWorkspaceTargetDetails` so inferred `cd` and `mvn -f` invocations do not allow shell metacharacters to be evaluated.
- Update tests in `test/validation.test.ts` to expect quoted nested paths and add a regression test that constructs a workspace directory containing a semicolon to assert the inferred command is quoted rather than executable as a shell fragment.

### Testing
- Ran the targeted unit tests with `npm test -- test/validation.test.ts` and the suite passed (1 file, 8 tests passed). 
- Ran static type checking with `npm run typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69cf2f4ebd348324910763f90861eb4e)