### PR TITLE
Harden prompt context by excluding README and AGENTS

### DIFF
--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -32,9 +32,7 @@ const REPOSITORY_CONTEXT_CANDIDATES = [
   "specs/001-plan-alignment/spec.md",
   "specs/001-plan-alignment/research.md",
   "sqlite-metadata-system.md",
-  "docs/project-readme.md",
-  "AGENTS.md",
-  "README.md"
+  "docs/project-readme.md"
 ];
 
 async function readPromptReferenceFiles(cwd: string, limit = 4): Promise<PromptReferenceFile[]> {

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -49,6 +49,8 @@ describe("buildBuildPrompt", () => {
     expect(prompt).toContain("### Patch resilience");
     expect(prompt).toContain("If `apply_patch` fails once, do not retry the same hunk unchanged");
     expect(prompt).toContain("If the file has mixed line endings, normalize them once before editing");
+    expect(prompt).not.toContain("### README.md");
     expect(context).toContain("Retry failure hints:");
+    expect(context).toContain("Reference files: none");
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent attacker-controlled root docs from being automatically embedded in LLM prompts by removing `README.md` and `AGENTS.md` from the default repository-context candidate list.

### Description
- Remove `"AGENTS.md"` and `"README.md"` from `REPOSITORY_CONTEXT_CANDIDATES` in `src/prompt.ts` so only curated project documents are considered for prompt context.
- Add assertions to `test/prompt.test.ts` to verify the workflow prompt does not contain README excerpts and that the context reports `Reference files: none` when only `README.md` exists.

### Testing
- Ran `npm test -- test/prompt.test.ts` and the test file passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69cd7ca5a1308324822e5dda131ce04b)