### PR TITLE
fix(validation): prevent validation lead from executing arbitrary local commands

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1412,6 +1412,17 @@ async function runCommandSet(cwd: string, runDir: string, commands: string[]): P
   };
 }
 
+function selectApprovedLocalValidationCommands(requested: string[], inferred: string[]): string[] {
+  const approved = new Set(uniqueStrings(inferred));
+  const selected: string[] = [];
+  for (const command of uniqueStrings(requested)) {
+    if (approved.has(command)) {
+      selected.push(command);
+    }
+  }
+  return selected;
+}
+
 async function runValidationSpecialist(options: {
   cwd: string;
   runId: string;
@@ -2107,12 +2118,16 @@ export async function runDeliverValidationExecution(options: DeliverValidationEx
         };
   }
 
+  const approvedLocalCommands = selectApprovedLocalValidationCommands(
+    validationPlan.localValidation.commands,
+    initialPlan.localValidation.commands
+  );
   const localValidationRecord: DeliverValidationLocalRecord =
     result.code === 0
-      ? await runCommandSet(options.cwd, options.paths.stageDir, validationPlan.localValidation.commands)
+      ? await runCommandSet(options.cwd, options.paths.stageDir, approvedLocalCommands)
       : {
           status: "not-run",
-          requestedCommands: validationPlan.localValidation.commands,
+          requestedCommands: approvedLocalCommands,
           results: [],
           notes: "Local validation commands were skipped because the validation lead did not complete successfully."
         };


### PR DESCRIPTION
### Motivation
- The validation lead could return arbitrary shell commands in its LLM-produced plan which were executed by `runCommandSet` via the system shell, creating a path for command injection and host compromise.
- The intent is to remove the trust boundary that directly executes model-supplied commands while preserving the deterministic, inferred local checks used by validation.

### Description
- Add `selectApprovedLocalValidationCommands(requested, inferred)` which dedupes and returns the intersection of the model-requested commands with the deterministic `initialPlan.localValidation.commands`.
- Use the approved command list (`approvedLocalCommands`) instead of `validationPlan.localValidation.commands` when invoking `runCommandSet` and when populating the `requestedCommands` field for skipped runs.
- Preserve existing `runCommandSet` behavior and tool-wrapper preparation so approved inferred commands run unchanged while any additional LLM-emitted commands are ignored.

### Testing
- Ran `npm test -- test/validation.test.ts`, which completed successfully (1 file passed, 6 tests passed).
- Ran `npm test -- test/deliver.test.ts`; the validation/deliver scenarios executed and produced logs, but the test run output was large and truncated in the execution environment so a final summary could not be captured here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69cd7fbb830483248bc7b763d6a4086f)