### PR TITLE
fix: prevent repo-configured GitHub command execution in deliver flows

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -100,23 +100,8 @@ async function pathExists(filePath: string): Promise<boolean> {
   }
 }
 
-function resolveCommand(command: string, args: string[]): { file: string; args: string[] } {
-  if (/\.(mjs|cjs|js|ts)$/i.test(command)) {
-    return {
-      file: process.execPath,
-      args: [command, ...args]
-    };
-  }
-
-  return {
-    file: command,
-    args
-  };
-}
-
 async function runCommand(command: string, args: string[], cwd: string): Promise<CommandResult> {
-  const invocation = resolveCommand(command, args);
-  const result = await execFileAsync(invocation.file, invocation.args, {
+  const result = await execFileAsync(command, args, {
     cwd,
     maxBuffer: 10 * 1024 * 1024,
     timeout: Number.parseInt(process.env.CSTACK_GITHUB_COMMAND_TIMEOUT_MS ?? "", 10) || DEFAULT_GITHUB_COMMAND_TIMEOUT_MS
@@ -1104,7 +1089,7 @@ export async function performGitHubDeliverMutations(options: PerformGitHubMutati
   );
   const remote = await resolveRemoteForPush(options.cwd);
   const { repository } = await detectRepository(options.cwd, policy.repository);
-  const ghCommand = policy.command || "gh";
+  const ghCommand = "gh";
   const defaultBranchInfo = await resolveDefaultBranch({ ghCommand, cwd: options.cwd, repository });
   const defaultBranch = defaultBranchInfo.name;
   let branch = options.gitBranch;
@@ -1619,7 +1604,7 @@ export async function collectGitHubDeliveryEvidence(options: CollectGitHubDelive
     };
   }
 
-  const ghCommand = policy.command || "gh";
+  const ghCommand = "gh";
   const { repository, remoteUrl } = await detectRepository(options.cwd, policy.repository);
   const headSha = await detectHeadSha(options.cwd);
   const defaultBranchInfo = await resolveDefaultBranch({ ghCommand, cwd: options.cwd, repository });

--- a/test/deliver.test.ts
+++ b/test/deliver.test.ts
@@ -99,13 +99,19 @@ async function initGitRepo(repoDir: string): Promise<{ remoteDir: string }> {
 describe("runDeliver", () => {
   let repoDir: string;
   let remoteDir: string;
+  let originalPath: string | undefined;
 
   beforeEach(async () => {
     repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "cstack-deliver-"));
     const fakeCodexPath = path.resolve("test/fixtures/fake-codex.mjs");
     const fakeGhPath = path.resolve("test/fixtures/fake-gh.mjs");
+    const fakeGhBinDir = await fs.mkdtemp(path.join(os.tmpdir(), "cstack-deliver-fake-gh-bin-"));
     chmodSync(fakeCodexPath, 0o755);
     chmodSync(fakeGhPath, 0o755);
+    await fs.copyFile(fakeGhPath, path.join(fakeGhBinDir, "gh"));
+    chmodSync(path.join(fakeGhBinDir, "gh"), 0o755);
+    originalPath = process.env.PATH;
+    process.env.PATH = `${fakeGhBinDir}${path.delimiter}${originalPath ?? ""}`;
 
     await fs.mkdir(path.join(repoDir, ".cstack", "prompts"), { recursive: true });
     await fs.mkdir(path.join(repoDir, ".cstack", "runs"), { recursive: true });
@@ -131,7 +137,7 @@ describe("runDeliver", () => {
         "",
         "[workflows.deliver.github]",
         'enabled = true',
-        `command = "${fakeGhPath.replaceAll("\\", "\\\\")}"`,
+        'command = "gh"',
         'repository = "ganesh47/cstack"',
         'pushBranch = true',
         'branchPrefix = "cstack"',
@@ -167,6 +173,7 @@ describe("runDeliver", () => {
   });
 
   afterEach(async () => {
+    process.env.PATH = originalPath;
     delete process.env.FAKE_CODEX_FAIL_BUILD;
     delete process.env.FAKE_CODEX_DELAY_MS;
     delete process.env.FAKE_CODEX_VALIDATION_COMMAND;
@@ -1599,7 +1606,7 @@ describe("runDeliver", () => {
       issueNumbers: [906],
       policy: {
         enabled: true,
-        command: path.resolve("test/fixtures/fake-gh.mjs"),
+        command: "gh",
         repository: "ganesh47/cstack",
         pushBranch: true,
         branchPrefix: "cstack",

--- a/test/ship.test.ts
+++ b/test/ship.test.ts
@@ -164,13 +164,19 @@ async function seedInitiativeReviewRun(repoDir: string, buildRunId: string): Pro
 describe("runShip", () => {
   let repoDir: string;
   let remoteDir: string;
+  let originalPath: string | undefined;
 
   beforeEach(async () => {
     repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "cstack-ship-"));
     const fakeCodexPath = path.resolve("test/fixtures/fake-codex.mjs");
     const fakeGhPath = path.resolve("test/fixtures/fake-gh.mjs");
+    const fakeGhBinDir = await fs.mkdtemp(path.join(os.tmpdir(), "cstack-ship-fake-gh-bin-"));
     chmodSync(fakeCodexPath, 0o755);
     chmodSync(fakeGhPath, 0o755);
+    await fs.copyFile(fakeGhPath, path.join(fakeGhBinDir, "gh"));
+    chmodSync(path.join(fakeGhBinDir, "gh"), 0o755);
+    originalPath = process.env.PATH;
+    process.env.PATH = `${fakeGhBinDir}${path.delimiter}${originalPath ?? ""}`;
 
     await fs.mkdir(path.join(repoDir, ".cstack", "prompts"), { recursive: true });
     await fs.mkdir(path.join(repoDir, ".cstack", "runs"), { recursive: true });
@@ -191,7 +197,7 @@ describe("runShip", () => {
         "",
         "[workflows.deliver.github]",
         'enabled = true',
-        `command = "${fakeGhPath.replaceAll("\\", "\\\\")}"`,
+        'command = "gh"',
         'repository = "ganesh47/cstack"',
         'pushBranch = true',
         'branchPrefix = "cstack"',
@@ -224,6 +230,7 @@ describe("runShip", () => {
   });
 
   afterEach(async () => {
+    process.env.PATH = originalPath;
     await fs.rm(repoDir, { recursive: true, force: true });
     await fs.rm(remoteDir, { recursive: true, force: true });
   });


### PR DESCRIPTION
### Motivation
- A repo-controlled `workflows.deliver.github.command` could point at a local script and be auto-executed during deliver evidence collection (when issue references are inferred), enabling arbitrary code execution under the user running `cstack deliver`.
- Deliver flows were resolving and invoking repo-configured script files (e.g. `.js/.ts`) via `execFile`, which bypasses sandbox expectations and is unsafe for untrusted repo config.
- The change prevents untrusted repository configuration from selecting an arbitrary executable for GitHub interactions.

### Description
- Removed the script/file extension resolution and Node-invocation path so commands are executed directly via `execFile` without implicitly routing scripts through `node` in `src/github.ts` (removed `resolveCommand`).
- Pinned GitHub invocations in deliver evidence collection and deliver mutation flows to the trusted `gh` binary by setting `ghCommand = "gh"` instead of using `policy.command` in `src/github.ts`.
- Updated tests in `test/deliver.test.ts` and `test/ship.test.ts` to create a fake `gh` binary on a temporary `PATH`, set the repo config `command = "gh"` in fixtures, and restore `PATH` in `afterEach` for deterministic behavior.

### Testing
- Ran `npx vitest run test/deliver.test.ts -t "fails closed when the default branch cannot be resolved for PR mutation"` and it passed.
- Ran `npx vitest run test/ship.test.ts -t "runShip"` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69cd824c69c08324800feb86fb44eef5)